### PR TITLE
Removing core tags cause they don't belong. 

### DIFF
--- a/crispy_forms/templates/bootstrap/field.html
+++ b/crispy_forms/templates/bootstrap/field.html
@@ -1,5 +1,4 @@
 {% load crispy_forms_field %}
-{% load core_tags %}
 
 {% if field.is_hidden %}
 	{{ field }}


### PR DESCRIPTION
FYI: This is why test projects inside an APP rock.
