### PR TITLE
Add control-label class to label

### DIFF
--- a/crispy_forms/templates/bootstrap/field.html
+++ b/crispy_forms/templates/bootstrap/field.html
@@ -5,7 +5,7 @@
 {% else %}
 	<div id="div_{{ field.auto_id }}" class="clearfix control-group{% if form_show_errors%}{% if field.errors %} error{% endif %}{% endif %} {% if field.field.widget.attrs.class %} {{ field.field.widget.attrs.class }}{% endif %}">
 		{% if field.label %}
-			<label for="{{ field.auto_id }}" {% if field.field.required %}class="requiredField"{% endif %}>
+			<label for="{{ field.auto_id }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
 				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
 			</label>
 		{% endif %}


### PR DESCRIPTION
This class is used only by horizontal-form. But it doesn't affect other layouts. So it's the simplest possible solution.
However a condition could be added which checks if the form helper has a form_class set to 'form-vertical'.
