### PR TITLE
Fix wrong closing tag in templates/bootstrap/layout/field_errors_block.html

### DIFF
--- a/crispy_forms/templates/bootstrap/layout/field_errors_block.html
+++ b/crispy_forms/templates/bootstrap/layout/field_errors_block.html
@@ -1,5 +1,5 @@
 {% if form_show_errors %}
     {% for error in field.errors %}
-        <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="help-block"><strong>{{ error }}</strong></span>
+        <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="help-block"><strong>{{ error }}</strong></p>
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
Should be closing p instead of span.
