### PR TITLE
test translation fix

### DIFF
--- a/crispy_forms/tests/tests.py
+++ b/crispy_forms/tests/tests.py
@@ -206,7 +206,7 @@ class TestFormHelpers(TestCase):
 
         # Ensure errors were not rendered
         self.assertFalse('<li>Passwords dont match</li>' in html)
-        self.assertFalse('This field is required.' in html)
+        self.assertFalse(unicode(_('This field is required.')) in html)
         self.assertFalse('error' in html)
 
     def test_crispy_tag_without_helper(self):


### PR DESCRIPTION
The `test_crispy_tag_with_helper_form_show_errors` (crispy_forms/tests/test.py, line 199) test fails if language is not english. When rendering template, "This field is required" is translated, so it should be tested against the translated version.
