### PR TITLE
Use safe filter on choices used in {% for x in y %}

### DIFF
--- a/crispy_forms/templates/bootstrap/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap/layout/checkboxselectmultiple.html
@@ -3,8 +3,8 @@
 
     {% for choice in field.field.choices %}
         <label class="checkbox">
-            <input type="checkbox" {% if choice.0 in field.value %}checked="checked" {% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0 }}">{{ choice.1 }}
-        </label> 
+            <input type="checkbox" {% if choice.0|safe in field.value %}checked="checked" {% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0 }}">{{ choice.1 }}
+        </label>
     {% endfor %}
 
     {% include 'bootstrap/layout/help_text.html' %}

--- a/crispy_forms/templates/bootstrap/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap/layout/radioselect.html
@@ -3,7 +3,7 @@
 
     {% for choice in field.field.choices %}
         <label class="radio">
-            <input type="radio" {% if choice.0 in field.value %}checked="checked" {% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0 }}">{{ choice.1 }}
+            <input type="radio" {% if choice.0|safe in field.value %}checked="checked" {% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0 }}">{{ choice.1 }}
         </label>
     {% endfor %}
 


### PR DESCRIPTION
Pertaining to issue #33:

When an integer is used as a choice value with MultipleChoiceField, the CheckBoxSelectMultijple template has a unicode/string mismatch that prevents initial values from getting rendered.

This is due to Django behavior (either intended or otherwise), and this fix works around the problem by using the `safe` filter, which has the side-effect of coercing the value to unicode.  This will not be a security threat as the value is not being rendered into the form, but is instead passed as an argument to a template tag.

For an illustration... in Python:

```
>>> '1' in ['1']
True
>>> '1' in [u'1']
True
```

The Django template tag `{% if choice.0 in field.value %}`, however, does not display the same symmetry.
