### PR TITLE
Fix for forms with less fields on instance than listed in Meta.fields

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -167,7 +167,8 @@ class FormHelper(object):
         # we suppose they need to be rendered. Othewise we renderd the
         # layout fields strictly
         if getattr(form, 'Meta', None):
-            fields = set(getattr(form.Meta, 'fields', []))
+            # Take the fields from the instance since the user might have deleted some
+            fields = set(getattr(form, 'fields', []))
             exclude = set(getattr(form.Meta, 'exclude', []))
             left_fields_to_render = fields - exclude - form.rendered_fields
 

--- a/crispy_forms/tests/tests.py
+++ b/crispy_forms/tests/tests.py
@@ -316,6 +316,29 @@ class TestFormLayout(TestCase):
         settings.CRISPY_FAIL_SILENTLY = False
         self.assertRaises(Exception, lambda:template.render(c))
         del settings.CRISPY_FAIL_SILENTLY
+        
+    def test_layout_uses_instance_for_missing_fields(self):
+        class FormWithMeta(TestForm):
+            class Meta:
+                fields = ('email', 'first_name', 'last_name')
+        form = FormWithMeta()
+        # We remove email field on the go
+        del form.fields['email']
+                
+        form_helper = FormHelper()
+        form_helper.add_layout(
+            Layout(
+                'first_name',
+            )
+        )
+
+        template = get_template_from_string(u"""
+            {% load crispy_forms_tags %}
+            {% crispy form form_helper %}
+        """)        
+        c = Context({'form': form, 'form_helper': form_helper})
+        html = template.render(c)
+        self.assertFalse('email' in html)
 
     def test_layout_unresolved_field(self):
         form = TestForm()


### PR DESCRIPTION
This fixes a problem where I delete fields from a form based on request parameters. I don't list these fields in the layout but crispy forms helpfully adds them to the layout and breaks on render.

This patch uses the .fields attribute from the form instance instead.
