### PR TITLE
Use `id_for_label` instead of `auto_id` in labels

### DIFF
--- a/crispy_forms/templates/bootstrap/field.html
+++ b/crispy_forms/templates/bootstrap/field.html
@@ -5,7 +5,7 @@
 {% else %}
 	<div id="div_{{ field.auto_id }}" class="clearfix control-group{% if form_show_errors%}{% if field.errors %} error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 		{% if field.label and not field|is_checkbox %}
-			<label for="{{ field.auto_id }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
+			<label for="{{ field.id_for_label }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
 				{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
 			</label>
 		{% endif %}
@@ -21,7 +21,7 @@
         {% if field|css_class != "checkboxselectmultiple" and field|css_class != "radioselect" %}
             <div class="controls">
                 {% if field|is_checkbox %}
-                    <label for="{{ field.auto_id }}" class="checkbox {% if field.field.required %}requiredField{% endif %}">
+                    <label for="{{ field.id_for_label }}" class="checkbox {% if field.field.required %}requiredField{% endif %}">
                         {% crispy_field field %}
                         {{ field.label|safe }}
                         {% include 'bootstrap/layout/help_text_and_errors.html' %}

--- a/crispy_forms/templates/bootstrap/field.strict.html
+++ b/crispy_forms/templates/bootstrap/field.strict.html
@@ -15,7 +15,7 @@
         {% endif %}
 
         {% if field.label %}
-            <label for="{{ field.auto_id }}" class="inlineLabel">
+            <label for="{{ field.id_for_label }}" class="inlineLabel">
                 {{ field.label|safe }}{% if field.field.required %}<em>*</em>{% endif %}
             </label>
         {% endif %}

--- a/crispy_forms/templates/bootstrap/layout/appended_text.html
+++ b/crispy_forms/templates/bootstrap/layout/appended_text.html
@@ -3,7 +3,7 @@
 <div id="div_{{ field.auto_id }}" class="clearfix control-group{% if field.errors %} error{% endif %} {% if field.field.widget.attrs.class %} {{ field.field.widget.attrs.class }}{% endif %}">
 
     {% if field.label %}
-        <label for="{{ field.auto_id }}" {% if field.field.required %}class="requiredField"{% endif %}>
+        <label for="{{ field.id_for_label }}" {% if field.field.required %}class="requiredField"{% endif %}>
             {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
         </label>
     {% endif %}

--- a/crispy_forms/templates/bootstrap/layout/multifield.html
+++ b/crispy_forms/templates/bootstrap/layout/multifield.html
@@ -5,7 +5,7 @@
 {% else %}
 
     {% if field.label %}
-        <label for="{{ field.auto_id }}"{% if labelclass %} class="{{ labelclass }}"{% endif %}>
+        <label for="{{ field.id_for_label }}"{% if labelclass %} class="{{ labelclass }}"{% endif %}>
     {% endif %}
 
     {% if field|is_checkbox %}

--- a/crispy_forms/templates/bootstrap/layout/prepended_text.html
+++ b/crispy_forms/templates/bootstrap/layout/prepended_text.html
@@ -3,7 +3,7 @@
 <div id="div_{{ field.auto_id }}" class="clearfix control-group{% if field.errors %} error{% endif %} {% if field.field.widget.attrs.class %} {{ field.field.widget.attrs.class }}{% endif %}">
 
     {% if field.label %}
-        <label for="{{ field.auto_id }}" {% if field.field.required %}class="requiredField"{% endif %}>
+        <label for="{{ field.id_for_label }}" {% if field.field.required %}class="requiredField"{% endif %}>
             {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
         </label>
     {% endif %}

--- a/crispy_forms/templates/uni_form/field.html
+++ b/crispy_forms/templates/uni_form/field.html
@@ -17,7 +17,7 @@
                 {% crispy_field field %}
             {% endif %}
 
-            <label for="{{ field.auto_id }}" {% if field.field.required %}class="requiredField"{% endif %}>
+            <label for="{{ field.id_for_label }}" {% if field.field.required %}class="requiredField"{% endif %}>
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}

--- a/crispy_forms/templates/uni_form/field.strict.html
+++ b/crispy_forms/templates/uni_form/field.strict.html
@@ -15,7 +15,7 @@
         {% endif %}
 
         {% if field.label %}
-            <label for="{{ field.auto_id }}" class="inlineLabel">
+            <label for="{{ field.id_for_label }}" class="inlineLabel">
                 {{ field.label|safe }}{% if field.field.required %}<em>*</em>{% endif %}
             </label>
         {% endif %}

--- a/crispy_forms/templates/uni_form/multifield.html
+++ b/crispy_forms/templates/uni_form/multifield.html
@@ -5,7 +5,7 @@
 {% else %}
     <div id="div_{{ field.auto_id }}" class="ctrlHolder {% if field|is_checkbox %}checkbox{% endif %} ">
         {% if field.label %}
-            <label for="{{ field.auto_id }}" {% if field.field.required %}class="requiredField"{% endif %}>
+            <label for="{{ field.id_for_label }}" {% if field.field.required %}class="requiredField"{% endif %}>
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}


### PR DESCRIPTION
`id_for_label` gives the intended id for field labels. `auto_id` happens
to work most of the time but breaks for multiwidgets.
