### PR TITLE
fix ValueError occuring on foreignkeys

### DIFF
--- a/crispy_forms/templates/uni_form/errors.html
+++ b/crispy_forms/templates/uni_form/errors.html
@@ -1,4 +1,4 @@
-{% if form.non_field_errors %}
+{% if form.errors and form.non_field_errors %}
     <div id="errorMsg">
         {% if form_error_title %}<h3>{{ form_error_title }}</h3>{% endif %}
         <ol>


### PR DESCRIPTION
in modelforms when form is initialized w/ data but has not been tested for validity and a foreign object has not been chosen

form.non_field_errors implicitly calls ForeignKey.save_form_data, somehow skipping field validation., which causes a ValueError during rendering.

this is a workaround to a problem that is obviously django's fault but i figured it would be useful to have upstream.
