### PR TITLE
Option to render Bootstrap form errors as a block rather than inline

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -161,6 +161,7 @@ class FormHelper(DynamicLayoutHandler):
     form_show_errors = True
     render_unmentioned_fields = False
     help_text_inline = False
+    error_text_inline = True
     html5_required = False
 
     def __init__(self, form=None):
@@ -258,6 +259,7 @@ class FormHelper(DynamicLayoutHandler):
         items['form_style'] = self.form_style.strip()
         items['form_show_errors'] = self.form_show_errors
         items['help_text_inline'] = self.help_text_inline
+        items['error_text_inline'] = self.error_text_inline
         items['html5_required'] = self.html5_required
 
         items['attrs'] = {}

--- a/crispy_forms/templates/bootstrap/layout/help_text_and_errors.html
+++ b/crispy_forms/templates/bootstrap/layout/help_text_and_errors.html
@@ -1,2 +1,6 @@
-{% include 'bootstrap/layout/field_errors.html' %}
+{% if error_text_inline %}
+    {% include 'bootstrap/layout/field_errors.html' %}
+{% else %}
+    {% include 'bootstrap/layout/field_errors_block.html' %}
+{% endif %}
 {% include 'bootstrap/layout/help_text.html' %}


### PR DESCRIPTION
Adds error_text_inline helper option for the Bootstrap template, defaulting to True, to preserve previous behavior, to allow rendering of form errors as a block rather than inline
