### PR TITLE
Consistent css class for prepended, appended inputs

### DIFF
--- a/crispy_forms/templates/bootstrap/layout/appended_prepended_text.html
+++ b/crispy_forms/templates/bootstrap/layout/appended_prepended_text.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="clearfix control-group{% if form_show_errors and field.errors %} error{% endif %} ">
+    <div id="div_{{ field.auto_id }}" class="clearfix control-group{% if form_show_errors and field.errors %} error{% endif %} {% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
             <label for="{{ field.id_for_label }}" class="control-label {% if field.field.required %}requiredField{% endif %}">

--- a/crispy_forms/templates/bootstrap/layout/appended_text.html
+++ b/crispy_forms/templates/bootstrap/layout/appended_text.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="clearfix control-group{% if form_show_errors and field.errors %} error{% endif %} {% if field.field.widget.attrs.class %} {{ field.field.widget.attrs.class }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="clearfix control-group{% if form_show_errors and field.errors %} error{% endif %} {% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
             <label for="{{ field.auto_id }}"  class="control-label {% if field.field.required %}requiredField {% endif %}">

--- a/crispy_forms/templates/bootstrap/layout/prepended_text.html
+++ b/crispy_forms/templates/bootstrap/layout/prepended_text.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="clearfix control-group{% if form_show_errors and field.errors %} error{% endif %} {% if field.field.widget.attrs.class %} {{ field.field.widget.attrs.class }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="clearfix control-group{% if form_show_errors and field.errors %} error{% endif %} {% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
             <label for="{{ field.id_for_label }}" class="control-label {% if field.field.required %}requiredField{% endif %}">


### PR DESCRIPTION
Fix issue where applying css class to Field will apply width to
control-group instead just input:

Field('days_interval', css_class="input-mini")
