### PR TITLE
use icons in help_text by setting help_text_icon in helper.layout.field

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -529,6 +529,8 @@ class Field(LayoutObject):
             else:
                 self.attrs['class'] = kwargs.pop('css_class')
 
+        self.help_text_icon = kwargs.pop('help_text_icon', None)
+        self.text_icon = kwargs.pop('text_icon', None)
         self.template = kwargs.pop('template', self.template)
 
         # We use kwargs as HTML attributes, turning data_id='test' into data-id='test'
@@ -537,7 +539,7 @@ class Field(LayoutObject):
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
         html = ''
         for field in self.fields:
-            html += render_field(field, form, form_style, context, template=self.template, attrs=self.attrs, template_pack=template_pack)
+            html += render_field(field, form, form_style, context, layout_object=self, template=self.template, attrs=self.attrs, template_pack=template_pack)
         return html
 
 

--- a/crispy_forms/templates/bootstrap/layout/help_text.html
+++ b/crispy_forms/templates/bootstrap/layout/help_text.html
@@ -1,7 +1,11 @@
 {% if field.help_text %}
     {% if help_text_inline %}
-        <span id="hint_{{ field.auto_id }}" class="help-inline">{{ field.help_text|safe }}</span>
+        <span id="hint_{{ field.auto_id }}" class="help-inline">
+        {% if help_text_icon %}<i class="icon-{{ help_text_icon }}"></i>{% endif %}
+        {{ field.help_text|safe }}</span>
     {% else %}
-        <p id="hint_{{ field.auto_id }}" class="help-block">{{ field.help_text|safe }}</p>
+        <span id="hint_{{ field.auto_id }}" class="help-block">
+        {% if help_text_icon %}<i class="icon-{{ help_text_icon }}"></i>{% endif %}
+        {{ field.help_text|safe }}</span>
     {% endif %}
 {% endif %}

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -117,6 +117,10 @@ def render_field(field, form, form_style, context, template=None, labelclass=Non
                 layout_object.bound_fields.append(bound_field)
             else:
                 layout_object.bound_fields = [bound_field]
+            if hasattr(layout_object, 'help_text_icon'):
+                context['help_text_icon'] = layout_object.help_text_icon
+            if hasattr(layout_object, 'text_icon'):
+                context['text_icon'] = layout_object.help_text_icon
 
         context.update({
             'field': bound_field,


### PR DESCRIPTION
I tryed to use crispy in my project, where I use bootstrap and font-awesome

I found that it is very difficult to add icons (`<i class="icon-foo"></i>`) to different parts of the form.
Still in many cases it is possible without using `HTML` layout or rewriting templates.
But when I needed to add an icon to `help_text` I ran into troubles: I had to rewrite `bootstrap/layout/help_text.html` hard-coding desired icon there. (I can't touch `forms.py`)
I don't know now to add second field with different help text icon without rewriting almost all `bootstrap/*` templates.

With this branch one can do it easy:

```
layout.Field(
    'fieldname',
    help_text_icon='info-sign',
),
```

This is just sort of prove of  concept, because I don't know crispy internals good enough...
