### PR TITLE
Don't display legend if not provided

### DIFF
--- a/crispy_forms/templates/uni_form/layout/fieldset.html
+++ b/crispy_forms/templates/uni_form/layout/fieldset.html
@@ -1,6 +1,6 @@
 <fieldset {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %} 
     {% if fieldset.css_class or form_style %}class="{{ fieldset.css_class }} {{ form_style }}"{% endif %}
     {{ fieldset.flat_attrs|safe }}>
-    <legend>{{ legend|safe }}</legend> 
+    {% if legend %}<legend>{{ legend|safe }}</legend>{% endif %}
     {{ fields|safe }} 
 </fieldset>


### PR DESCRIPTION
Allow for fieldsets to not have a legend:

```
self.helper.layout = Layout(
        Fieldset(
            None,
            'email', 
            'first_name',
            'last_name'
            ),
        Fieldset(
            _('Groups'),
            'group'
            ),
        Fieldset(
            _('Options'),
            'all_invoices'
            )
        )
```
