### PR TITLE
Use formset iterator instead of forms list attribute

### DIFF
--- a/crispy_forms/templates/bootstrap/uni_formset.html
+++ b/crispy_forms/templates/bootstrap/uni_formset.html
@@ -1,7 +1,7 @@
 {% with formset.management_form as form %}
     {% include 'bootstrap/uni_form.html' %}
 {% endwith %}
-{% for form in formset.forms %}
+{% for form in formset %}
     <div class="multiField">
         {% include 'bootstrap/uni_form.html' %}
     </div>

--- a/crispy_forms/templates/bootstrap/whole_uni_formset.html
+++ b/crispy_forms/templates/bootstrap/whole_uni_formset.html
@@ -15,7 +15,7 @@
 
     {% include "bootstrap/errors_formset.html" %}
 
-    {% for form in formset.forms %}
+    {% for form in formset %}
         {% include "bootstrap/display_form.html" %}
     {% endfor %}
 

--- a/crispy_forms/templates/uni_form/uni_formset.html
+++ b/crispy_forms/templates/uni_form/uni_formset.html
@@ -1,7 +1,7 @@
 {% with formset.management_form as form %}
     {% include 'uni_form/uni_form.html' %}
 {% endwith %}
-{% for form in formset.forms %}
+{% for form in formset %}
     <div class="multiField">
         {% include 'uni_form/uni_form.html' %}
     </div>

--- a/crispy_forms/templates/uni_form/whole_uni_formset.html
+++ b/crispy_forms/templates/uni_form/whole_uni_formset.html
@@ -13,7 +13,7 @@
 
     {% include "uni_form/errors_formset.html" %}
 
-    {% for form in formset.forms %}
+    {% for form in formset %}
         {% include "uni_form/display_form.html" %}
     {% endfor %}
 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -123,7 +123,7 @@ class BasicNode(template.Node):
                 actual_form.form_html = helper.render_layout(actual_form, node_context, template_pack=self.template_pack)
             else:
                 forloop = ForLoopSimulator(actual_form)
-                for form in actual_form.forms:
+                for form in actual_form:
                     node_context.update({'forloop': forloop})
                     form.form_html = helper.render_layout(form, node_context, template_pack=self.template_pack)
                     forloop.iterate()


### PR DESCRIPTION
Custom BaseFormSet subclasses may override `__iter__` to change the rendering order of the forms within the formset.  I removed references to the `forms` attribute in loops so that `__iter__` will be used instead.
