### PR TITLE
Render <legend> only if there is a legend

### DIFF
--- a/crispy_forms/templates/uni_form/layout/fieldset.html
+++ b/crispy_forms/templates/uni_form/layout/fieldset.html
@@ -1,6 +1,8 @@
 <fieldset {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %} 
     {% if fieldset.css_class or form_style %}class="{{ fieldset.css_class }} {{ form_style }}"{% endif %}
     {{ fieldset.flat_attrs|safe }}>
-    <legend>{{ legend|safe }}</legend> 
+    {% if legend %}
+        <legend>{{ legend|safe }}</legend>
+    {% endif %}
     {{ fields|safe }} 
 </fieldset>


### PR DESCRIPTION
Fieldset legends are rendered even if there is no legend.
This extra `{%if %}` fixes this
