### PR TITLE
Pop "css_id" to stop it being added as a "css-id" attribute

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -171,7 +171,7 @@ class BaseInput(object):
     def __init__(self, name, value, **kwargs):
         self.name = name
         self.value = value
-        self.id = kwargs.get('css_id', '')
+        self.id = kwargs.pop('css_id', '')
         self.attrs = {}
 
         if 'css_class' in kwargs:


### PR DESCRIPTION
Changed `BaseInput` so that it pops the "css_id" from kwargs.

Previously it was updating the "self.id" and then being flattened to "css-id" leading to an odd attribute.

Before:

``` html
<input other-attributes id="new-submit-id" css-id="new-submit-id">
```

After:

``` html
<input other-attributes id="new-submit-id">
```
