### PR TITLE
bootstrap tab: "active" class is added several times, and to several tabs

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -192,7 +192,10 @@ class Container(Div):
 
     def render(self, form, form_style, context):
         if self.active:
-            self.css_class += ' active'
+            if not 'active' in self.css_class:
+                self.css_class += ' active'
+        else:
+            self.css_class = self.css_class.replace('active', '')
         return super(Container, self).render(form, form_style, context)
 
 
@@ -244,6 +247,8 @@ class TabHolder(ContainerHolder):
 
     def render(self, form, form_style, context, template_pack='bootstrap'):
         links, content = '', ''
+        for tab in self.fields:
+            tab.active = False
 
         # The first tab with errors will be active
         self.first_container_with_errors(form.errors.keys()).active = True


### PR DESCRIPTION
When used as class attributes on a form, the bootstrap.Container and bootstrap.TabHolder helpers are not properly reinitialized, which leads to duplicate css "active" attribute, and (in case of error on tab) to several tabs being active together.

Example:

```
class TestForm(forms.Form):
    val1 = forms.CharField(required=False)
    val2 = forms.CharField(required=True)
    helper = FormHelper()
    helper.layout = Layout(
        TabHolder(Tab('one', 'val1',),
                        Tab('two', 'val2',)))

test_form = TestForm()
html = render_crispy_form(test_form)
... 
<div id="one" class="tab-pane active"
...
# render again
test_form = TestForm()
html = render_crispy_form(test_form)
...
<div id="one" class="tab-pane active active"
...

# ...and again
test_form = TestForm()
html = render_crispy_form(test_form)
...
<div id="one" class="tab-pane active active active"
...

# render with incomplete POST (form error)
test_form = TestForm(data={'val1':'foo'})
html = render_crispy_form(test_form)
# both tabs are active now
...
<div id="one" class="tab-pane active
...
<div id="two" class="tab-pane active
...
```

Attached patch and test fixes this for Tab/Container
