### PR TITLE
Access keys() for both dict and RequesContext

### DIFF
--- a/crispy_forms/base.py
+++ b/crispy_forms/base.py
@@ -22,10 +22,10 @@ class KeepContext(object):
         self.context = context
 
     def __enter__(self):
-        self.old_set_keys = set(from_iterable([dict.keys() for dict in self.context.dicts]))
+        self.old_set_keys = set(from_iterable([d.keys() if isinstance(d,dict) else d.__dict__.keys() for d in self.context.dicts]))
 
     def __exit__(self, type, value, traceback):
-        current_set_keys = set(from_iterable([dict.keys() for dict in self.context.dicts]))
+        current_set_keys = set(from_iterable([d.keys() if isinstance(d,dict) else d.__dict__.keys() for d in self.context.dicts]))
         diff_keys = current_set_keys - self.old_set_keys
 
         # We remove added keys for rolling back changes


### PR DESCRIPTION
Note that the current implementation would fail (in some cases - like mine where I render the form with a RequestContext ) when rendering Layout() elements on the helper, since under the KeepContext's **enter** and **exit** you assume that all "dicts" shall expose the keys() method, which doesn't happen for RequestContext objects.
