### PR TITLE
Some basic test support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: develop test
+
+develop:
+	pip install -q "file://`pwd`#egg=django-crispy-forms[tests]"
+	pip install -q -e . --use-mirrors
+
+test: develop
+	cd crispy_forms/tests && python runtests.py

--- a/crispy_forms/tests/runtests.py
+++ b/crispy_forms/tests/runtests.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 
 import os
+import sys
 
-os.system('python runtests_bootstrap.py')
-os.system('python runtests_uniform.py')
+cmds = [
+    'python runtests_bootstrap.py',
+    'python runtests_uniform.py',
+]
+
+for cmd in cmds:
+    retval = os.system(cmd)
+    if retval:
+        sys.exit(retval)

--- a/crispy_forms/tests/test_settings_bootstrap.py
+++ b/crispy_forms/tests/test_settings_bootstrap.py
@@ -27,3 +27,20 @@ ROOT_URLCONF = 'urls'
 CRISPY_TEMPLATE_PACK = 'bootstrap'
 CRISPY_CLASS_CONVERTERS = {"textinput": "textinput textInput inputtext"}
 SECRET_KEY = 'secretkey'
+
+# http://djangosnippets.org/snippets/646/
+class InvalidVarException(object):
+    def __mod__(self, missing):
+        try:
+            missing_str = unicode(missing)
+        except:
+            missing_str = 'Failed to create string representation'
+        raise Exception('Unknown template variable %r %s' % (missing, missing_str))
+
+    def __contains__(self, search):
+        if search == '%s':
+            return True
+        return False
+
+TEMPLATE_DEBUG = True
+TEMPLATE_STRING_IF_INVALID = InvalidVarException()

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,10 @@ import crispy_forms
 from setuptools import setup, find_packages
 
 
+tests_require = [
+    'Django>=1.2,<1.6',
+]
+
 setup(
     name='django-crispy-forms',
     version=crispy_forms.__version__,
@@ -21,6 +25,9 @@ setup(
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
+    extras_require={
+        'tests': tests_require,
+    },
     keywords=['forms', 'django', 'crispy', 'DRY'],
     author='Miguel Araujo',
     author_email='miguel.araujo.perez@gmail.com',


### PR DESCRIPTION
`make test`

Magic.

I see three failures locally:

```
======================================================================
FAIL: test_formset_layout (crispy_forms.tests.tests.TestFormLayout)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dcramer/Development/django-crispy-forms/crispy_forms/tests/tests.py", line 935, in test_formset_layout
    ), 1)
AssertionError: 0 != 1

======================================================================
FAIL: test_modelformset_layout (crispy_forms.tests.tests.TestFormLayout)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dcramer/Development/django-crispy-forms/crispy_forms/tests/tests.py", line 988, in test_modelformset_layout
    ), 1)
AssertionError: 0 != 1

----------------------------------------------------------------------
```

The third being an undefined template variable (inline_class) which gets hit in as_crispy_field
