### PR TITLE
Exploit from_iterable() for Contexts with no __dict__

### DIFF
--- a/crispy_forms/base.py
+++ b/crispy_forms/base.py
@@ -22,10 +22,10 @@ class KeepContext(object):
         self.context = context
 
     def __enter__(self):
-        self.old_set_keys = set(from_iterable([d.keys() if isinstance(d,dict) else d.__dict__.keys() for d in self.context.dicts]))
+        self.old_set_keys = set(from_iterable(self.context.dicts))
 
     def __exit__(self, type, value, traceback):
-        current_set_keys = set(from_iterable([d.keys() if isinstance(d,dict) else d.__dict__.keys() for d in self.context.dicts]))
+        current_set_keys = set(from_iterable(self.context.dicts))
         diff_keys = current_set_keys - self.old_set_keys
 
         # We remove added keys for rolling back changes


### PR DESCRIPTION
As @nvie pointed out to me, my earlier patch "breaks for people who are using Jingo/Jinja2 templates, since their Context has no attribute `__dict__`."

So after a couple of suggestions, we realized, and I've tested this locally too, that this new approach works well (for probably all applicable cases).
