### PR TITLE
Make tests compatible with both `runtests.py` and `manage.py test`

### DIFF
--- a/crispy_forms/tests/test_settings_bootstrap.py
+++ b/crispy_forms/tests/test_settings_bootstrap.py
@@ -28,9 +28,6 @@ CRISPY_TEMPLATE_PACK = 'bootstrap'
 CRISPY_CLASS_CONVERTERS = {"textinput": "textinput textInput inputtext"}
 SECRET_KEY = 'secretkey'
 SITE_ROOT = os.path.dirname(os.path.abspath(__file__))
-TEMPLATE_DIRS = (
-    os.path.join(SITE_ROOT, 'templates'),
-)
 
 
 # http://djangosnippets.org/snippets/646/


### PR DESCRIPTION
I suppose it would be nice if we can test crispy_forms with both `runtests.py` and `manage.py test`.

It allows us to test both
- crispy_forms for all template packs (with `runtests.py`)
- the way crispy_forms is integrated into custom Django project (with `manage.py test`)

The pull request fixes existing incompatibilities with `manage.py test` (#181 and #182).
