### PR TITLE
Python 3 compatibility.

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -5,6 +5,7 @@ from django.template import Context, Template
 from django.template.loader import render_to_string
 from django.template.defaultfilters import slugify
 
+from .compatibility import text_type
 from .layout import LayoutObject, Field, Div
 from .utils import render_field, flatatt
 
@@ -166,7 +167,7 @@ class StrictButton(object):
         self.flat_attrs = flatatt(kwargs)
 
     def render(self, form, form_style, context):
-        self.content = Template(unicode(self.content)).render(context)
+        self.content = Template(text_type(self.content)).render(context)
         return render_to_string(self.template, Context({'button': self}))
 
 
@@ -208,7 +209,7 @@ class ContainerHolder(Div):
         Returns the first container with errors, otherwise returns the first one
         """
         for tab in self.fields:
-            errors_here = bool(filter(lambda error: error in tab, errors))
+            errors_here = any(error in tab for error in errors)
             if errors_here:
                 return tab
 
@@ -292,7 +293,7 @@ class Accordion(ContainerHolder):
         # accordion group needs the parent div id to set `data-parent` (I don't
         # know why). This needs to be a unique id
         if not self.css_id:
-            self.css_id = "-".join(["accordion", str(randint(1000, 9999))])
+            self.css_id = "-".join(["accordion", text_type(randint(1000, 9999))])
 
         # first group with errors or first groupt will be visible, others will be collapsed
         self.first_container_with_errors(form.errors.keys()).active = True

--- a/crispy_forms/compatibility.py
+++ b/crispy_forms/compatibility.py
@@ -1,0 +1,14 @@
+import sys
+
+
+PY2 = sys.version_info[0] == 2
+if not PY2:
+    text_type = str
+    binary_type = bytes
+    string_types = (str,)
+    integer_types = (int,)
+else:
+    text_type = unicode
+    binary_type = str
+    string_types = basestring
+    integer_types = (int, long)

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -1,6 +1,7 @@
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.utils.safestring import mark_safe
 
+from crispy_forms.compatibility import string_types
 from crispy_forms.layout import Layout
 from crispy_forms.layout_slice import LayoutSlice
 from crispy_forms.utils import render_field, flatatt, TEMPLATE_PACK
@@ -71,7 +72,7 @@ class DynamicLayoutHandler(object):
         and not a copy.
         """
         # when key is a string containing the field name
-        if isinstance(key, basestring):
+        if isinstance(key, string_types):
             # Django templates access FormHelper attributes using dictionary [] operator
             # This could be a helper['form_id'] access, not looking for a field
             if hasattr(self, key):

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -5,6 +5,7 @@ from django.template import Context, Template
 from django.template.loader import render_to_string
 from django.utils.html import conditional_escape
 
+from crispy_forms.compatibility import string_types, text_type
 from crispy_forms.utils import render_field, flatatt
 
 TEMPLATE_PACK = getattr(settings, 'CRISPY_TEMPLATE_PACK', 'bootstrap')
@@ -44,7 +45,7 @@ class LayoutObject(object):
                [[0,3], 'field_name2']
             ]
         """
-        return self.get_layout_objects(basestring, greedy=True)
+        return self.get_layout_objects(string_types, greedy=True)
 
     def get_layout_objects(self, *LayoutClasses, **kwargs):
         """
@@ -74,7 +75,7 @@ class LayoutObject(object):
 
         for i, layout_object in enumerate(self.fields):
             if isinstance(layout_object, LayoutClasses):
-                if len(LayoutClasses) == 1 and LayoutClasses[0] == basestring:
+                if len(LayoutClasses) == 1 and LayoutClasses[0] == string_types:
                     pointers.append([index + [i], layout_object])
                 else:
                     pointers.append([index + [i], layout_object.__class__.__name__.lower()])
@@ -190,7 +191,7 @@ class BaseInput(object):
         Renders an `<input />` if container is used as a Layout object.
         Input button value can be a variable in context.
         """
-        self.value = Template(unicode(self.value)).render(context)
+        self.value = Template(text_type(self.value)).render(context)
         return render_to_string(self.template, Context({'input': self}))
 
 
@@ -276,7 +277,7 @@ class Fieldset(LayoutObject):
 
         legend = ''
         if self.legend:
-            legend = u'%s' % Template(unicode(self.legend)).render(context)
+            legend = u'%s' % Template(text_type(self.legend)).render(context)
         return render_to_string(self.template, Context({'fieldset': self, 'legend': legend, 'fields': fields, 'form_style': form_style}))
 
 
@@ -377,7 +378,7 @@ class HTML(object):
         self.html = html
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
-        return Template(unicode(self.html)).render(context)
+        return Template(text_type(self.html)).render(context)
 
 
 class Field(LayoutObject):

--- a/crispy_forms/layout_slice.py
+++ b/crispy_forms/layout_slice.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from crispy_forms.compatibility import integer_types
 from crispy_forms.exceptions import DynamicError
 from crispy_forms.layout import Fieldset, MultiField
 from crispy_forms.bootstrap import Container
@@ -10,7 +11,7 @@ class LayoutSlice(object):
 
     def __init__(self, layout, key):
         self.layout = layout
-        if isinstance(key, (int, long)):
+        if isinstance(key, integer_types):
             self.slice = slice(key, key+1, 1)
         else:
             self.slice = key

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -1,4 +1,7 @@
-from itertools import izip
+try:
+    from itertools import izip
+except ImportError:
+    izip = zip
 
 from django import forms
 from django import template

--- a/crispy_forms/templatetags/crispy_forms_utils.py
+++ b/crispy_forms/templatetags/crispy_forms_utils.py
@@ -2,17 +2,22 @@
 import re
 
 from django import template
-from django.utils.encoding import force_unicode
+try:  # Django < 1.4
+    from django.utils.encoding import force_unicode as force_text
+except ImportError:
+    from django.utils.encoding import force_text
 from django.utils.functional import allow_lazy
+
+from crispy_forms.compatibility import text_type
 
 register = template.Library()
 
 
 def selectively_remove_spaces_between_tags(value):
-    html = re.sub(r'>\s+<', '><', force_unicode(value))
-    html = re.sub(r'</button><', '</button> <', force_unicode(html))
-    return re.sub(r'(<input[^>]+>)<', r'\1 <', force_unicode(html))
-selectively_remove_spaces_between_tags = allow_lazy(selectively_remove_spaces_between_tags, unicode)
+    html = re.sub(r'>\s+<', '><', force_text(value))
+    html = re.sub(r'</button><', '</button> <', force_text(html))
+    return re.sub(r'(<input[^>]+>)<', r'\1 <', force_text(html))
+selectively_remove_spaces_between_tags = allow_lazy(selectively_remove_spaces_between_tags, text_type)
 
 
 class SpecialSpacelessNode(template.Node):

--- a/crispy_forms/tests/test_settings_bootstrap.py
+++ b/crispy_forms/tests/test_settings_bootstrap.py
@@ -1,5 +1,8 @@
 import os
 
+from crispy_forms.compatibility import text_type
+
+
 BASE_DIR = os.path.dirname(__file__)
 
 INSTALLED_APPS = (
@@ -37,7 +40,7 @@ TEMPLATE_DIRS = (
 class InvalidVarException(object):
     def __mod__(self, missing):
         try:
-            missing_str = unicode(missing)
+            missing_str = text_type(missing)
         except:
             missing_str = 'Failed to create string representation'
         raise Exception('Unknown template variable %r %s' % (missing, missing_str))

--- a/crispy_forms/tests/tests.py
+++ b/crispy_forms/tests/tests.py
@@ -14,6 +14,7 @@ from django.shortcuts import render_to_response
 from django.test import TestCase, RequestFactory
 from django.utils.translation import ugettext_lazy as _
 
+from crispy_forms.compatibility import string_types, text_type
 from crispy_forms.exceptions import DynamicError
 from crispy_forms.helper import FormHelper, FormHelpersException
 from crispy_forms.layout import Submit, Reset, Hidden, Button
@@ -229,7 +230,7 @@ class TestFormHelpers(TestCase):
 
         # Ensure those errors were rendered
         self.assertTrue('<li>Passwords dont match</li>' in html)
-        self.assertTrue(unicode(_('This field is required.')) in html)
+        self.assertTrue(text_type(_('This field is required.')) in html)
         self.assertTrue('error' in html)
 
         # Now we render without errors
@@ -239,7 +240,7 @@ class TestFormHelpers(TestCase):
 
         # Ensure errors were not rendered
         self.assertFalse('<li>Passwords dont match</li>' in html)
-        self.assertFalse(unicode(_('This field is required.')) in html)
+        self.assertFalse(text_type(_('This field is required.')) in html)
         self.assertFalse('error' in html)
 
     def test_form_show_errors(self):
@@ -1131,7 +1132,7 @@ class TestFormLayout(TestCase):
         context = RequestContext(request, {'form': form})
 
         response = render_to_response('crispy_render_template.html', context)
-        self.assertEqual(response.content.count('checkbox inline'), 3)
+        self.assertEqual(response.content.count(b'checkbox inline'), 3)
 
 
 class TestLayoutObjects(TestCase):
@@ -1445,12 +1446,12 @@ class TestDynamicLayouts(TestCase):
         )
         helper.layout = layout
 
-        helper.filter(basestring, greedy=True).wrap_once(Field)
+        helper.filter(string_types, greedy=True).wrap_once(Field)
         helper.filter(Field, greedy=True).update_attributes(readonly=True)
 
         self.assertTrue(isinstance(layout[0], Field))
         self.assertTrue(isinstance(layout[1][0], Field))
-        self.assertTrue(isinstance(layout[1][0][0], basestring))
+        self.assertTrue(isinstance(layout[1][0][0], string_types))
         self.assertTrue(isinstance(layout[2], Field))
         self.assertEqual(layout[1][0].attrs, {'readonly': True})
         self.assertEqual(layout[0].attrs, {'readonly': True})
@@ -1493,7 +1494,7 @@ class TestDynamicLayouts(TestCase):
             Div('password1'),
             'password2',
         )
-        self.assertEqual(layout_3.get_layout_objects(basestring, max_level=2), [
+        self.assertEqual(layout_3.get_layout_objects(string_types, max_level=2), [
             [[0], 'email'],
             [[1, 0], 'password1'],
             [[2], 'password2']
@@ -1549,7 +1550,7 @@ class TestDynamicLayouts(TestCase):
         )
         helper.layout = layout
 
-        helper.filter(basestring).wrap(Field, css_class="test-class")
+        helper.filter(string_types).wrap(Field, css_class="test-class")
         self.assertTrue(isinstance(layout.fields[0], Field))
         self.assertTrue(isinstance(layout.fields[1], Div))
         self.assertTrue(isinstance(layout.fields[2], Field))
@@ -1690,8 +1691,8 @@ class TestDynamicLayouts(TestCase):
         self.assertTrue(isinstance(form.helper.layout[1], Field))
         # Check others stay the same
         self.assertTrue(isinstance(form.helper.layout[0][3][1], HTML))
-        self.assertTrue(isinstance(form.helper.layout[0][1][0][0], basestring))
-        self.assertTrue(isinstance(form.helper.layout[0][4][0], basestring))
+        self.assertTrue(isinstance(form.helper.layout[0][1][0][0], string_types))
+        self.assertTrue(isinstance(form.helper.layout[0][4][0], string_types))
 
     def test_all_without_layout(self):
         form = TestForm()
@@ -1764,8 +1765,8 @@ class TestDynamicLayouts(TestCase):
         self.assertTrue(isinstance(layout[0][0], Div))
         self.assertTrue(isinstance(layout[0][0][0], Div))
         self.assertTrue(isinstance(layout[0][1], Div))
-        self.assertTrue(isinstance(layout[0][1][0], basestring))
-        self.assertTrue(isinstance(layout[0][2], basestring))
+        self.assertTrue(isinstance(layout[0][1][0], string_types))
+        self.assertTrue(isinstance(layout[0][2], string_types))
 
     def test__getattr__append_layout_object(self):
         layout = Layout(
@@ -1773,8 +1774,8 @@ class TestDynamicLayouts(TestCase):
         )
         layout.append('password1')
         self.assertTrue(isinstance(layout[0], Div))
-        self.assertTrue(isinstance(layout[0][0], basestring))
-        self.assertTrue(isinstance(layout[1], basestring))
+        self.assertTrue(isinstance(layout[0][0], string_types))
+        self.assertTrue(isinstance(layout[1], string_types))
 
     def test__setitem__layout_object(self):
         layout = Layout(

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -10,7 +10,8 @@ from django.template.loader import get_template
 from django.utils.html import conditional_escape
 from django.utils.functional import memoize
 
-from base import KeepContext
+from .base import KeepContext
+from .compatibility import text_type
 
 # Global field template, default template used for rendering a field.
 
@@ -56,12 +57,12 @@ def render_field(field, form, form_style, context, template=None, labelclass=Non
         else:
             # This allows fields to be unicode strings, always they don't use non ASCII
             try:
-                if isinstance(field, unicode):
-                    field = str(field)
+                if isinstance(field, text_type):
+                    field = field.encode('ascii').decode()
                 # If `field` is not unicode then we turn it into a unicode string, otherwise doing
                 # str(field) would give no error and the field would not be resolved, causing confusion
                 else:
-                    field = str(unicode(field))
+                    field = text_type(field)
 
             except (UnicodeEncodeError, UnicodeDecodeError):
                 raise Exception("Field '%s' is using forbidden unicode characters" % field)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "Programming Language :: JavaScript",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.3",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
This is a pretty blind python 3 compatibility conversion that may well have completely missed the point of any or all of the code it touches. It does, however get all but one of the tests passing on python 3.3 and 2.7 (with django 1.6 pre-alpha, and 1.5 respectively).

I do not understand why `TestLayoutObjects.test_tab_helper_reuse` does not pass.
