### PR TITLE
Adding crispy add on tag

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -2,6 +2,7 @@ from itertools import izip
 
 from django import forms
 from django import template
+from django.template import loader, Context
 from django.conf import settings
 
 
@@ -127,3 +128,34 @@ def crispy_field(parser, token):
         attrs[attribute_name] = value
 
     return CrispyFieldNode(field, attrs)
+
+
+@register.simple_tag()
+def crispy_addon(field, append="", prepend=""):
+    """
+    Renders a form field using bootstrap's prepended or appended text:
+        Usage:
+        {% crispy_addon form.my_field prepend="$" append=".00" %}
+        You can also just prepend or append like so
+        {% crispy_addon form.my_field prepend="$" %}
+        {% crispy_addon form.my_field append=".00" %}
+    """
+    if (field):
+        context = Context({
+            'field': field,
+            'form_show_errors': True })
+
+        if (prepend and append):
+            template = loader.get_template('bootstrap/layout/appended_prepended_text.html')
+            context['crispy_prepended_text'] = prepend
+            context['crispy_appended_text'] = append
+        elif prepend:
+            template = loader.get_template('bootstrap/layout/prepended_text.html')
+            context['crispy_prepended_text'] = prepend
+        elif append:
+            template = loader.get_template('bootstrap/layout/appended_text.html')
+            context['crispy_appended_text'] = append
+        else:
+            raise TypeError("Expected a prepend and/or append argument")
+
+    return template.render(context)

--- a/crispy_forms/tests/tests.py
+++ b/crispy_forms/tests/tests.py
@@ -28,6 +28,7 @@ from crispy_forms.bootstrap import (
 )
 from crispy_forms.utils import render_crispy_form
 from crispy_forms.templatetags.crispy_forms_tags import CrispyFormNode
+from crispy_forms.templatetags.crispy_forms_field import crispy_addon
 
 from crispy_forms.tests.forms import (
     TestForm, TestForm2, TestForm3, ExampleForm, CheckboxesTestForm,
@@ -124,6 +125,23 @@ class TestBasicFunctionalityTags(TestCase):
             self.assertTrue('error' in html)
             self.assertTrue('inputtext' in html)
 
+    def test_crispy_addon(self):
+        test_form = TestForm()
+        field_instance = test_form.fields['email']
+        bound_field = BoundField(test_form, field_instance, 'email')
+        # prepend tests
+        self.assertIn("input-prepend", crispy_addon(bound_field, prepend="Work"))
+        self.assertNotIn("input-append", crispy_addon(bound_field, prepend="Work"))
+        # append tests
+        self.assertNotIn("input-prepend", crispy_addon(bound_field, append="Primary"))
+        self.assertIn("input-append", crispy_addon(bound_field, append="Secondary"))
+        # prepend and append tests
+        self.assertIn("input-append", crispy_addon(bound_field, prepend="Work", append="Primary"))
+        self.assertIn("input-prepend", crispy_addon(bound_field, prepend="Work", append="Secondary"))
+        # errors
+        with self.assertRaises(TypeError):
+            crispy_addon()
+            crispy_addon(bound_field)
 
 class TestFormHelpers(TestCase):
     urls = 'crispy_forms.tests.urls'


### PR DESCRIPTION
Here is the refactored crispy add on field as discussed in this issue: https://github.com/maraujop/django-crispy-forms/issues/186

Again, this template tag allows bootstrap users to prepend and append inputs with text.
