### PR TITLE
Add override_settings backport in order to support Django 1.3 in tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.3"
 env:
+  - DJANGO=1.3.7
   - DJANGO=1.4.5
   - DJANGO=1.5.1
 install:
@@ -18,3 +19,5 @@ matrix:
   exclude:
     - python: "3.3"
       env: DJANGO=1.4.5
+    - python: "3.3"
+      env: DJANGO=1.3.7

--- a/crispy_forms/tests/tests.py
+++ b/crispy_forms/tests/tests.py
@@ -13,7 +13,6 @@ from django.template import loader
 from django.middleware.csrf import _get_new_csrf_key
 from django.shortcuts import render_to_response
 from django.test import TestCase, RequestFactory
-from django.test.utils import override_settings
 from django.utils.translation import ugettext_lazy as _
 
 from crispy_forms.compatibility import string_types, text_type
@@ -37,6 +36,7 @@ from crispy_forms.tests.forms import (
     TestForm, TestForm2, TestForm3, ExampleForm, CheckboxesTestForm,
     FormWithMeta, TestForm4, CrispyTestModel
 )
+from crispy_forms.tests.utils import override_settings
 
 
 class CrispyTestCase(TestCase):

--- a/crispy_forms/tests/utils.py
+++ b/crispy_forms/tests/utils.py
@@ -1,0 +1,68 @@
+__all__ = ('override_settings',)
+
+
+try:
+    from django.test.utils import override_settings
+except ImportError:
+    # we are in Django 1.3
+    from django.conf import settings, UserSettingsHolder
+    from django.utils.functional import wraps
+
+    class override_settings(object):
+        """
+        Acts as either a decorator, or a context manager. If it's a decorator
+        it takes a function and returns a wrapped function. If it's a
+        contextmanager it's used with the ``with`` statement. In either event
+        entering/exiting are called before and after, respectively,
+        the function/block is executed.
+
+        This class was backported from Django 1.5
+
+        As django.test.signals.setting_changed is not supported in 1.3,
+        it's not sent on changing settings.
+        """
+        def __init__(self, **kwargs):
+            self.options = kwargs
+            self.wrapped = settings._wrapped
+
+        def __enter__(self):
+            self.enable()
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            self.disable()
+
+        def __call__(self, test_func):
+            from django.test import TransactionTestCase
+            if isinstance(test_func, type):
+                if not issubclass(test_func, TransactionTestCase):
+                    raise Exception(
+                        "Only subclasses of Django SimpleTestCase "
+                        "can be decorated with override_settings")
+                original_pre_setup = test_func._pre_setup
+                original_post_teardown = test_func._post_teardown
+
+                def _pre_setup(innerself):
+                    self.enable()
+                    original_pre_setup(innerself)
+
+                def _post_teardown(innerself):
+                    original_post_teardown(innerself)
+                    self.disable()
+                test_func._pre_setup = _pre_setup
+                test_func._post_teardown = _post_teardown
+                return test_func
+            else:
+                @wraps(test_func)
+                def inner(*args, **kwargs):
+                    with self:
+                        return test_func(*args, **kwargs)
+            return inner
+
+        def enable(self):
+            override = UserSettingsHolder(settings._wrapped)
+            for key, new_value in self.options.items():
+                setattr(override, key, new_value)
+            settings._wrapped = override
+
+        def disable(self):
+            settings._wrapped = self.wrapped


### PR DESCRIPTION
Added a backported version of `override_settings` for Django 1.3

In fact we could strip out contextmanager and decorator support (methods `__enter__`, `__exit__`, `__call__`), but I suppose we should follow Django's `override_settings` interface as close as possible.
