### PR TITLE
Change  default value of form_show_labels to True

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -168,7 +168,7 @@ class BasicNode(template.Node):
             'form_show_errors': attrs.get("form_show_errors", True),
             'help_text_inline': attrs.get("help_text_inline", False),
             'html5_required': attrs.get("html5_required", False),
-            'form_show_labels': attrs.get("form_show_labels", False),
+            'form_show_labels': attrs.get("form_show_labels", True),
             'disable_csrf': attrs.get("disable_csrf", False),
             'inputs': attrs.get('inputs', []),
             'is_formset': is_formset,


### PR DESCRIPTION
I think the default value for form_show_labels must be True. Also as shown in the documentation.
