### PR TITLE
Allow to configure template_pack in FormHelper

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -1,4 +1,4 @@
-import warnings
+﻿import warnings
 from random import randint
 
 from django.template import Context, Template
@@ -11,7 +11,7 @@ from .utils import render_field, flatatt
 
 
 class AppendedText(Field):
-    template = "bootstrap/layout/appended_text.html"
+    template = "/layout/appended_text.html"
 
     def __init__(self, field, text, *args, **kwargs):
         self.field = field
@@ -23,19 +23,21 @@ class AppendedText(Field):
 
     def render(self, form, form_style, context, template_pack='bootstrap'):
         context.update({'crispy_appended_text': self.text, 'active': getattr(self, "active", False)})
-        return render_field(self.field, form, form_style, context, template=self.template, attrs=self.attrs, template_pack=template_pack)
+        template = template_pack + self.template
+        return render_field(self.field, form, form_style, context, template=template, attrs=self.attrs, template_pack=template_pack)
 
 
 class PrependedText(AppendedText):
-    template = "bootstrap/layout/prepended_text.html"
+    template = "/layout/prepended_text.html"
 
     def render(self, form, form_style, context, template_pack='bootstrap'):
         context.update({'crispy_prepended_text': self.text, 'active': getattr(self, "active", False)})
-        return render_field(self.field, form, form_style, context, template=self.template, attrs=self.attrs, template_pack=template_pack)
+        template = template_pack + self.template
+        return render_field(self.field, form, form_style, context, template=template, attrs=self.attrs, template_pack=template_pack)
 
 
 class PrependedAppendedText(Field):
-    template = "bootstrap/layout/appended_prepended_text.html"
+    template = "/layout/appended_prepended_text.html"
 
     def __init__(self, field, prepended_text=None, appended_text=None, *args, **kwargs):
         self.field = field
@@ -50,7 +52,8 @@ class PrependedAppendedText(Field):
         context.update({'crispy_appended_text': self.appended_text,
                         'crispy_prepended_text': self.prepended_text,
                         'active': getattr(self, "active", False)})
-        return render_field(self.field, form, form_style, context, template=self.template, attrs=self.attrs, template_pack=template_pack)
+        template = template_pack + self.template
+        return render_field(self.field, form, form_style, context, template=template, attrs=self.attrs, template_pack=template_pack)
 
 
 class AppendedPrependedText(PrependedAppendedText):
@@ -71,7 +74,7 @@ class FormActions(LayoutObject):
             Submit('Save', 'Save', css_class='btn-primary')
         )
     """
-    template = "bootstrap/layout/formactions.html"
+    template = "/layout/formactions.html"
 
     def __init__(self, *fields, **kwargs):
         self.fields = list(fields)
@@ -84,8 +87,8 @@ class FormActions(LayoutObject):
         html = u''
         for field in self.fields:
             html += render_field(field, form, form_style, context, template_pack=template_pack)
-
-        return render_to_string(self.template, Context({'formactions': self, 'fields_output': html}))
+        template = template_pack + self.template
+        return render_to_string(template, Context({'formactions': self, 'fields_output': html}))
 
     def flat_attrs(self):
         return flatatt(self.attrs)
@@ -97,11 +100,12 @@ class InlineCheckboxes(Field):
 
         InlineCheckboxes('field_name')
     """
-    template = "bootstrap/layout/checkboxselectmultiple_inline.html"
+    template = "/layout/checkboxselectmultiple_inline.html"
 
     def render(self, form, form_style, context, template_pack='bootstrap'):
         context.update({'inline_class': 'inline'})
-        return super(InlineCheckboxes, self).render(form, form_style, context)
+        template = template_pack + self.template
+        return super(InlineCheckboxes, self).render(form, form_style, context, template_pack)
 
 
 class InlineRadios(Field):
@@ -110,36 +114,38 @@ class InlineRadios(Field):
 
         InlineRadios('field_name')
     """
-    template = "bootstrap/layout/radioselect_inline.html"
+    template = "/layout/radioselect_inline.html"
 
     def render(self, form, form_style, context, template_pack='bootstrap'):
         context.update({'inline_class': 'inline'})
-        return super(InlineRadios, self).render(form, form_style, context)
+        return super(InlineRadios, self).render(form, form_style, context, template_pack)
 
 
 class FieldWithButtons(Div):
-    template = 'bootstrap/layout/field_with_buttons.html'
+    template = '/layout/field_with_buttons.html'
 
-    def render(self, form, form_style, context):
+    def render(self, form, form_style, context, template_pack='bootstrap'):
         # We first render the buttons
         buttons = ''
         for field in self.fields[1:]:
             buttons += render_field(
                 field, form, form_style, context,
-                'bootstrap/layout/field.html', layout_object=self
+                template_pack + '/layout/field.html', layout_object=self
             )
 
         context.update({'div': self, 'buttons': buttons})
+
+        template = template_pack + self.template
 
         if isinstance(self.fields[0], Field):
             # FieldWithButtons(Field('field_name'), StrictButton("go"))
             # We render the field passing its name and attributes
             return render_field(
                 self.fields[0][0], form, form_style, context,
-                self.template, attrs=self.fields[0].attrs
+                template, attrs=self.fields[0].attrs
             )
         else:
-            return render_field(self.fields[0], form, form_style, context, self.template)
+            return render_field(self.fields[0], form, form_style, context, template)
 
 
 class StrictButton(object):
@@ -148,7 +154,7 @@ class StrictButton(object):
 
         Button("button content", css_class="extra")
     """
-    template = 'bootstrap/layout/button.html'
+    template = '/layout/button.html'
     field_classes = 'btn'
 
     def __init__(self, content, **kwargs):
@@ -166,9 +172,10 @@ class StrictButton(object):
 
         self.flat_attrs = flatatt(kwargs)
 
-    def render(self, form, form_style, context):
+    def render(self, form, form_style, context, template_pack = 'bootstrap'):
         self.content = Template(text_type(self.content)).render(context)
-        return render_to_string(self.template, Context({'button': self}))
+        template = template_pack + self.template
+        return render_to_string(template, Context({'button': self}))
 
 
 class Container(Div):
@@ -191,13 +198,13 @@ class Container(Div):
         """
         return field_name in map(lambda pointer: pointer[1], self.get_field_names())
 
-    def render(self, form, form_style, context):
+    def render(self, form, form_style, context, template_pack='bootstrap'):
         if self.active:
             if not 'active' in self.css_class:
                 self.css_class += ' active'
         else:
             self.css_class = self.css_class.replace('active', '')
-        return super(Container, self).render(form, form_style, context)
+        return super(Container, self).render(form, form_style, context, template_pack)
 
 
 class ContainerHolder(Div):
@@ -224,14 +231,15 @@ class Tab(Container):
         Tab('tab_name', 'form_field_1', 'form_field_2', 'form_field_3')
     """
     css_class = 'tab-pane'
-    link_template = 'bootstrap/layout/tab-link.html'
+    link_template = '/layout/tab-link.html'
 
-    def render_link(self):
+    def render_link(self,template_pack='bootstrap'):
         """
         Render the link for the tab-pane. It must be called after render so css_class is updated
         with active if needed.
         """
-        return render_to_string(self.link_template, Context({'link': self}))
+        link_template = template_pack + self.link_template
+        return render_to_string(link_template, Context({'link': self}))
 
 
 class TabHolder(ContainerHolder):
@@ -243,7 +251,7 @@ class TabHolder(ContainerHolder):
             Tab('form_field_3')
         )
     """
-    template = 'bootstrap/layout/tab.html'
+    template = '/layout/tab.html'
     css_class = 'nav nav-tabs'
 
     def render(self, form, form_style, context, template_pack='bootstrap'):
@@ -258,9 +266,11 @@ class TabHolder(ContainerHolder):
             content += render_field(
                 tab, form, form_style, context, template_pack=template_pack
             )
-            links += tab.render_link()
+            links += tab.render_link(template_pack)
 
-        return render_to_string(self.template, Context({
+        template = template_pack + self.template
+
+        return render_to_string(template, Context({
             'tabs': self, 'links': links, 'content': content
         }))
 
@@ -272,7 +282,7 @@ class AccordionGroup(Container):
 
         AccordionGroup("group name", "form_field_1", "form_field_2")
     """
-    template = "bootstrap/accordion-group.html"
+    template = "/accordion-group.html"
     data_parent = ""  # accordion parent div id.
 
 
@@ -285,7 +295,7 @@ class Accordion(ContainerHolder):
             AccordionGroup("another group name", "form_field")
         )
     """
-    template = "bootstrap/accordion.html"
+    template = "/accordion.html"
 
     def render(self, form, form_style, context, template_pack='bootstrap'):
         content = ''
@@ -304,7 +314,9 @@ class Accordion(ContainerHolder):
                 group, form, form_style, context, template_pack=template_pack
             )
 
+        template = template_pack + self.template
+
         return render_to_string(
-            self.template,
+            template,
             Context({'accordion': self, 'content': content
         }))

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -1,4 +1,4 @@
-import warnings
+﻿import warnings
 
 from django.conf import settings
 from django.template import Context, Template
@@ -151,7 +151,7 @@ class ButtonHolder(LayoutObject):
             Submit('Save', 'Save')
         )
     """
-    template = "uni_form/layout/buttonholder.html"
+    template = "/layout/buttonholder.html"
 
     def __init__(self, *fields, **kwargs):
         self.fields = list(fields)
@@ -165,14 +165,16 @@ class ButtonHolder(LayoutObject):
             html += render_field(field, form, form_style,
                                  context, template_pack=template_pack)
 
-        return render_to_string(self.template, Context({'buttonholder': self, 'fields_output': html}))
+        template = template_pack + self.template
+
+        return render_to_string(template, Context({'buttonholder': self, 'fields_output': html}))
 
 
 class BaseInput(object):
     """
     A base class to reduce the amount of code in the Input classes.
     """
-    template = "%s/layout/baseinput.html" % TEMPLATE_PACK
+    template = "/layout/baseinput.html"
 
     def __init__(self, name, value, **kwargs):
         self.name = name
@@ -192,7 +194,8 @@ class BaseInput(object):
         Input button value can be a variable in context.
         """
         self.value = Template(text_type(self.value)).render(context)
-        return render_to_string(self.template, Context({'input': self}))
+        template = template_pack + self.template
+        return render_to_string(template, Context({'input': self}))
 
 
 class Submit(BaseInput):
@@ -258,7 +261,7 @@ class Fieldset(LayoutObject):
             'form_field_2'
         )
     """
-    template = "uni_form/layout/fieldset.html"
+    template = "/layout/fieldset.html"
 
     def __init__(self, legend, *fields, **kwargs):
         self.fields = list(fields)
@@ -278,13 +281,14 @@ class Fieldset(LayoutObject):
         legend = ''
         if self.legend:
             legend = u'%s' % Template(text_type(self.legend)).render(context)
-        return render_to_string(self.template, Context({'fieldset': self, 'legend': legend, 'fields': fields, 'form_style': form_style}))
+        template = template_pack + self.template
+        return render_to_string(template, Context({'fieldset': self, 'legend': legend, 'fields': fields, 'form_style': form_style}))
 
 
 class MultiField(LayoutObject):
     """ MultiField container. Renders to a MultiField <div> """
-    template = "uni_form/layout/multifield.html"
-    field_template = "uni_form/multifield.html"
+    template = "/layout/multifield.html"
+    field_template = "/multifield.html"
 
     def __init__(self, label, *fields, **kwargs):
         self.fields = list(fields)
@@ -303,16 +307,18 @@ class MultiField(LayoutObject):
                 if field in form.errors:
                     self.css_class += " error"
 
+        field_template = template_pack + self.field_template
         fields_output = u''
         for field in self.fields:
             fields_output += render_field(
                 field, form, form_style, context,
-                self.field_template, self.label_class, layout_object=self,
+                field_template, self.label_class, layout_object=self,
                 template_pack=template_pack
             )
 
         context.update({'multifield': self, 'fields_output': fields_output})
-        return render_to_string(self.template, context)
+        template = template_pack + self.template
+        return render_to_string(template, context)
 
 
 class Div(LayoutObject):
@@ -323,7 +329,7 @@ class Div(LayoutObject):
 
         Div('form_field_1', 'form_field_2', css_id='div-example', css_class='divs')
     """
-    template = "uni_form/layout/div.html"
+    template = "/layout/div.html"
 
     def __init__(self, *fields, **kwargs):
         self.fields = list(fields)
@@ -341,8 +347,8 @@ class Div(LayoutObject):
         fields = ''
         for field in self.fields:
             fields += render_field(field, form, form_style, context, template_pack=template_pack)
-
-        return render_to_string(self.template, Context({'div': self, 'fields': fields}))
+        template = template_pack + self.template
+        return render_to_string(template, Context({'div': self, 'fields': fields}))
 
 
 class Row(Div):
@@ -390,7 +396,7 @@ class Field(LayoutObject):
 
         Field('field_name', style="color: #333;", css_class="whatever", id="field_name")
     """
-    template = "%s/field.html" % TEMPLATE_PACK
+    template = "/field.html"
 
     def __init__(self, *args, **kwargs):
         self.fields = list(args)
@@ -413,10 +419,10 @@ class Field(LayoutObject):
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK):
         if hasattr(self, 'wrapper_class'):
             context['wrapper_class'] = self.wrapper_class
-
+        template = template_pack + self.template
         html = ''
         for field in self.fields:
-            html += render_field(field, form, form_style, context, template=self.template, attrs=self.attrs, template_pack=template_pack)
+            html += render_field(field, form, form_style, context, template=template, attrs=self.attrs, template_pack=template_pack)
         return html
 
 
@@ -451,7 +457,7 @@ class UneditableField(Field):
 
         UneditableField('field_name', css_class="input-xlarge")
     """
-    template = "bootstrap/layout/uneditable_input.html"
+    template = "/layout/uneditable_input.html"
 
     def __init__(self, field, *args, **kwargs):
         self.attrs = {'class': 'uneditable-input'}

--- a/crispy_forms/templates/bootstrap/layout/div.html
+++ b/crispy_forms/templates/bootstrap/layout/div.html
@@ -1,0 +1,4 @@
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
+    {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
+       {{ fields|safe }}
+</div>

--- a/crispy_forms/templates/bootstrap/layout/fieldset.html
+++ b/crispy_forms/templates/bootstrap/layout/fieldset.html
@@ -1,0 +1,6 @@
+<fieldset {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %} 
+    {% if fieldset.css_class or form_style %}class="{{ fieldset.css_class }} {{ form_style }}"{% endif %}
+    {{ fieldset.flat_attrs|safe }}>
+    {% if legend %}<legend>{{ legend|safe }}</legend>{% endif %}
+    {{ fields|safe }} 
+</fieldset>

--- a/crispy_forms/templates/bootstrap/table_inline_formset.html
+++ b/crispy_forms/templates/bootstrap/table_inline_formset.html
@@ -48,7 +48,7 @@
     {% if inputs %}
         <div class="form-actions">
             {% for input in inputs %}
-                {% include "uni_form/layout/baseinput.html" %}
+                {% include "bootstrap/layout/baseinput.html" %}
             {% endfor %}
         </div>
     {% endif %}

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -56,7 +56,7 @@ def css_class(field):
 
 
 def pairwise(iterable):
-    "s -> (s0,s1), (s2,s3), (s4, s5), ..."
+    """s -> (s0,s1), (s2,s3), (s4, s5), ..."""
     a = iter(iterable)
     return izip(a, a)
 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 from copy import copy
 
 from django.conf import settings
@@ -111,6 +111,11 @@ class BasicNode(template.Node):
             # If the user names the helper within the form `helper` (standard), we use it
             # This allows us to have simplified tag syntax: {% crispy form %}
             helper = FormHelper() if not hasattr(actual_form, 'helper') else actual_form.helper
+
+        try:
+            self.template_pack = helper.template_pack
+        except AttributeError:
+            pass
 
         self.actual_helper = helper
 
@@ -258,7 +263,7 @@ def do_uni_form(parser, token):
         # {% crispy form 'bootstrap' %}
         # ('"'bootstrap'"', '"'uni_form'"','"'"bootstrap'"'", '"'"uni_form"'")
         if (
-            helper in ['"%s"' % x for x in ALLOWED_TEMPLATE_PACKS] + \
+            helper in ['"%s"' % x for x in ALLOWED_TEMPLATE_PACKS] +
             ["'%s'" % x for x in ALLOWED_TEMPLATE_PACKS]
         ):
             template_pack = helper[1:-1]

--- a/crispy_forms/tests/tests.py
+++ b/crispy_forms/tests/tests.py
@@ -36,7 +36,7 @@ from crispy_forms.tests.forms import (
     TestForm, TestForm2, TestForm3, ExampleForm, CheckboxesTestForm,
     FormWithMeta, TestForm4, CrispyTestModel, TestForm5
 )
-from crispy_forms.tests.utils import override_settings
+from crispy_forms.tests.utils import override_settings, OnlyIfTemplatePack
 
 
 class CrispyTestCase(TestCase):
@@ -280,6 +280,7 @@ class TestFormHelpers(CrispyTestCase):
         self.assertFalse(text_type(_('This field is required.')) in html)
         self.assertFalse('error' in html)
 
+    @OnlyIfTemplatePack('bootstrap')
     def test_form_show_errors(self):
         form = TestForm({
             'email': 'invalidemail',
@@ -293,7 +294,8 @@ class TestFormHelpers(CrispyTestCase):
             AppendedText('email', 'whatever'),
             PrependedText('first_name', 'blabla'),
             AppendedPrependedText('last_name', 'foo', 'bar'),
-            MultiField('legend', 'password1', 'password2')
+            AppendedText('password1', 'xxx'),
+            PrependedText('password2', 'yyy'),
         )
         form.is_valid()
 
@@ -305,6 +307,7 @@ class TestFormHelpers(CrispyTestCase):
         html = render_crispy_form(form)
         self.assertEqual(html.count('error'), 0)
 
+    @OnlyIfTemplatePack('uni_form')
     def test_multifield_errors(self):
         form = TestForm({
             'email': 'invalidemail',
@@ -342,6 +345,7 @@ class TestFormHelpers(CrispyTestCase):
         form.helper.html5_required = False
         html = render_crispy_form(form)
 
+    @OnlyIfTemplatePack('bootstrap')
     def test_error_text_inline(self):
         form = TestForm({'email': 'invalidemail'})
         form.helper = FormHelper()
@@ -746,6 +750,7 @@ class TestFormLayout(CrispyTestCase):
         self.assertEqual(html.count('name="comment"'), 2)
         self.assertEqual(html.count('name="is_company"'), 1)
 
+    @OnlyIfTemplatePack('bootstrap')
     def test_hidden_fields(self):
         form = TestForm()
         # All fields hidden
@@ -765,6 +770,7 @@ class TestFormLayout(CrispyTestCase):
         self.assertEqual(html.count('type="hidden"'), 5)
         self.assertEqual(html.count('<label'), 0)
 
+    @OnlyIfTemplatePack('bootstrap')
     def test_field_with_buttons(self):
         form = TestForm()
         form.helper = FormHelper()
@@ -853,6 +859,7 @@ class TestFormLayout(CrispyTestCase):
         self.assertTrue('Hello!' in html)
         self.assertTrue('testLink' in html)
 
+    @OnlyIfTemplatePack('uni_form')
     def test_second_layout_multifield_column_buttonholder_submit_div(self):
         form_helper = FormHelper()
         form_helper.add_layout(
@@ -911,6 +918,7 @@ class TestFormLayout(CrispyTestCase):
         self.assertTrue('class="customdivs"' in html)
         self.assertTrue('test-markup="123"' in html)
 
+    @OnlyIfTemplatePack('uni_form')
     def test_layout_within_layout(self):
         form_helper = FormHelper()
         form_helper.add_layout(
@@ -1189,6 +1197,7 @@ class TestFormLayout(CrispyTestCase):
         self.assertTrue('email' in html)
         self.assertFalse('password' in html)
 
+    @OnlyIfTemplatePack('bootstrap')
     def test_multiplecheckboxes(self):
         test_form = CheckboxesTestForm()
         html = render_crispy_form(test_form)
@@ -1202,6 +1211,7 @@ class TestFormLayout(CrispyTestCase):
         self.assertEqual(html.count('checkbox inline"'), 3)
         self.assertEqual(html.count('inline"'), 3)
 
+    @OnlyIfTemplatePack('bootstrap')
     def test_keepcontext_context_manager(self):
         # Test case for issue #180
         # Apparently it only manifest when using render_to_response this exact way
@@ -1270,6 +1280,7 @@ class TestLayoutObjects(CrispyTestCase):
             html = Field('checkboxes').render(form, "", Context())
             self.assertTrue('class="checkbox"' in html)
 
+    @OnlyIfTemplatePack('bootstrap')
     def test_appended_prepended_text(self):
         test_form = TestForm()
         test_form.helper = FormHelper()
@@ -1286,6 +1297,7 @@ class TestLayoutObjects(CrispyTestCase):
         self.assertEqual(html.count('<span class="add-on">#</span>'), 1)
         self.assertEqual(html.count('<span class="add-on">$</span>'), 1)
 
+    @OnlyIfTemplatePack('bootstrap')
     def test_inline_radios(self):
         test_form = CheckboxesTestForm()
         test_form.helper = FormHelper()
@@ -1294,6 +1306,7 @@ class TestLayoutObjects(CrispyTestCase):
 
         self.assertEqual(html.count('radio inline"'), 2)
 
+    @OnlyIfTemplatePack('bootstrap')
     def test_accordion_and_accordiongroup(self):
         test_form = TestForm()
         test_form.helper = FormHelper()
@@ -1320,6 +1333,7 @@ class TestLayoutObjects(CrispyTestCase):
         self.assertEqual(html.count('name="password1"'), 1)
         self.assertEqual(html.count('name="password2"'), 1)
 
+    @OnlyIfTemplatePack('bootstrap')
     def test_tab_and_tabholder(self):
         test_form = TestForm()
         test_form.helper = FormHelper()
@@ -1347,6 +1361,7 @@ class TestLayoutObjects(CrispyTestCase):
         self.assertEqual(html.count('name="password1"'), 1)
         self.assertEqual(html.count('name="password2"'), 1)
 
+    @OnlyIfTemplatePack('bootstrap')
     def test_tab_helper_reuse(self):
         # this is a proper form, according to the docs.
         # note that the helper is a class property here,

--- a/crispy_forms/tests/utils.py
+++ b/crispy_forms/tests/utils.py
@@ -1,5 +1,7 @@
 __all__ = ('override_settings',)
 
+from crispy_forms.compatibility import string_types
+from django.utils.unittest import skipUnless
 
 try:
     from django.test.utils import override_settings
@@ -66,3 +68,25 @@ except ImportError:
 
         def disable(self):
             settings._wrapped = self.wrapped
+
+
+class OnlyIfTemplatePack(object):
+    """
+    This decorated is used to skip tests that are specific for just a specific
+    template pack(s)
+    """
+    def __init__(self,template_pack_or_tuple):
+        if isinstance(template_pack_or_tuple, string_types):
+            self.template_packs = [template_pack_or_tuple,]
+        else:
+            self.template_packs = template_pack_or_tuple
+    def __call__(self, func):
+        decorator_self = self
+        def wrapped( *args, **kwargs):
+            from crispy_forms.layout import TEMPLATE_PACK
+            return skipUnless(
+                TEMPLATE_PACK in decorator_self.template_packs,
+                'template pack is not in ' + repr(decorator_self.template_packs))(func)(*args, **kwargs)
+        return wrapped
+
+


### PR DESCRIPTION
## The problem

I wanted to render forms using different template packs.
Currently, this cannot be achieved because all layout elements use the same template pack.
## The solution

Add a `template_pack` option to `FormHelper`, which will override `CRISPY_TEMPLATE_PACK` if defined.
### Changes
- Each layout elements defines `self.template` related to the template pack, e.g. `"/layout/appended_text.html"` instead of `"bootstrap/layout/appended_text.html"`
- The `render()` function prepends `template_pack` to `self.template`.
- Separate the `bootstrap` and the `uni_form` template packs completely, i.e. templates from one should not reference templates from the other. Some templates, e.g. `div.html`, where only in `uni_form` so I copied them to `bootstrap`.
- Some tests are performed only on specific template packs.
## Considerations
- Some layout elements are only relevant to specific template pack. What should happen when a user is using a wrong template pack, e.g. when using `bootstrap` to render `MultiField`?
