### PR TITLE
Use github for dev installs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -11,7 +11,8 @@ Install latest stable version into your python path using pip or easy_install::
 
 If you want to install development version (unstable), you can do so doing::
 
-    pip install django-crispy-forms==dev
+    pip install git+git://github.com/maraujop/django-crispy-forms.git\
+    @dev#egg=django-crispy-forms
 
 Add ``crispy_forms`` to your ``INSTALLED_APPS`` in settings.py::
 


### PR DESCRIPTION
The old command doesn't work as 'dev' version isn't found:

``` bash
$ pip install django-crispy-forms==dev
Downloading/unpacking django-crispy-forms==dev
  Could not find a version that satisfies the requirement django-crispy-forms==dev (from versions: 1.2.4, 1.0.0, 1.1.1, 1.1.2, 1.2.7, 1.1.4, 1.1.3, 1.2.0, 1.2.6, 1.2.1, 1.2.5, 1.2.2, 1.3.0, 1.3.2, 1.2.3, 1.3.1, 1.2.8)
No distributions matching the version for django-crispy-forms==dev
```
