### PR TITLE
Update crispy_tag_formsets.rst

### DIFF
--- a/docs/crispy_tag_formsets.rst
+++ b/docs/crispy_tag_formsets.rst
@@ -23,6 +23,7 @@ Of course, you can still use a helper, otherwise there would be nothing crispy i
 
     class ExampleFormSetHelper(FormHelper):
         def __init__(self, *args, **kwargs):
+            super(ExampleFormSetHelper, self).__init__(*args, **kwargs)
             self.form_method = 'post'
             self.layout = Layout(
                 'favorite_color',


### PR DESCRIPTION
Update ExampleFormSetHelper example so that it calls `super`, otherwise an exception will be generated when rendering the formset using `{% crispy formset helper %}`.
