### PR TITLE
Fix for #237 : Fixing 'Settings' object has no attribute 'CRISPY_TEMPLATE_PACK' error

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -157,7 +157,7 @@ class BasicNode(template.Node):
 
         # We take form/formset parameters from attrs if they are set, otherwise we use defaults
         response_dict = {
-            'template_pack': settings.CRISPY_TEMPLATE_PACK,
+            'template_pack': TEMPLATE_PACK,
             '%s_action' % form_type: attrs['attrs'].get("action", ''),
             '%s_method' % form_type: attrs.get("form_method", 'post'),
             '%s_tag' % form_type: attrs.get("form_tag", True),


### PR DESCRIPTION
Bug reported here - #237
