### PR TITLE
Fixed #245 -- The first ``AccordionGroup`` can now be set `active=False`

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -92,3 +92,4 @@ Contributors
 * Camilo Nova <camilonova>
 * <mrkre>
 * Daniel Mascarenhas <danielmt>
+* Christopher Adams <adamsc64>

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -207,6 +207,43 @@ class TestBootstrapLayoutObjects(CrispyTestCase):
         self.assertEqual(html.count('name="password1"'), 1)
         self.assertEqual(html.count('name="password2"'), 1)
 
+    def test_accordion_active_false_not_rendered(self):
+        test_form = TestForm()
+        test_form.helper = FormHelper()
+        test_form.helper.layout = Layout(
+            Accordion(
+                AccordionGroup(
+                    'one',
+                    'first_name',
+                ),
+                # there is no ``active`` kwarg here.
+            )
+        )
+
+        # The first time, there should be one of them there.
+        html = render_crispy_form(test_form)
+
+        if self.current_template_pack == 'bootstrap':
+            accordion_class = "accordion-body"
+        else:
+            accordion_class = "panel-collapse"
+
+        self.assertEqual(html.count('<div id="one" class="%s collapse in"' % accordion_class), 1)
+
+        test_form.helper.layout = Layout(
+            Accordion(
+                AccordionGroup(
+                    'one',
+                    'first_name',
+                    active=False,  # now ``active`` manually set as False
+                ),
+            )
+        )
+
+        # This time, it shouldn't be there at all.
+        html = render_crispy_form(test_form)
+        self.assertEqual(html.count('<div id="one" class="%s collapse in"' % accordion_class), 0)
+
     def test_alert(self):
         test_form = TestForm()
         test_form.helper = FormHelper()


### PR DESCRIPTION
- Changed it so that if the user initializes the first `AccordionGroup` with the `active=False` kwarg, that first group will not be initially visible at page load.
- Kept the original default behavior, which renders the first group when the `active` kwarg is not set at all. Therefore, the change should be fully backwards compatible.
- Unit test written for new functionality.
- All previous unit tests pass.
