### PR TITLE
Appending/Prepending select buttons leaves a weird box with the button c...

### DIFF
--- a/crispy_forms/templates/bootstrap/layout/prepend_append_select_button.html
+++ b/crispy_forms/templates/bootstrap/layout/prepend_append_select_button.html
@@ -1,0 +1,25 @@
+{% load crispy_forms_field %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    <div id="div_{{ field.auto_id }}" class="control-group{% if form_show_errors and field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+
+        {% if field.label and form_show_labels %}
+            <label for="{{ field.id_for_label }}" class="control-label{% if field.field.required %} requiredField{% endif %}">
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            </label>
+        {% endif %}
+
+        <div class="controls">
+            <div class="{% if crispy_prepended_text %}input-prepend{% endif %} {% if crispy_appended_text %}input-append{% endif %}">
+                {# Removed 'add-on' class since that creates the box and shifts the button to be centered in it. #}
+                {% if crispy_prepended_text %}<span class="{% if active %} active{% endif %}">{{ crispy_prepended_text|safe }}</span>{% endif %}
+                {% crispy_field field %}
+                {% if crispy_appended_text %}<span class="{% if active %} active{% endif %}">{{ crispy_appended_text|safe }}</span>{% endif %}
+            </div>
+
+            {% include 'bootstrap/layout/help_text_and_errors.html' %}
+        </div>
+    </div>
+{% endif %}


### PR DESCRIPTION
...entered below it. Removing the 'add-on' class from the div leaves the button exactly where it should be with a flatter side.

There might be a way to load this template if the field is a select list in the Prepended/AppendedText field types.
