### PR TITLE
switch away from deprecated setup_environ in sphinx conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,9 +22,8 @@ sys.path.insert(0, os.path.abspath('../crispy_forms'))
 sys.path.insert(0, os.path.abspath('../crispy_forms/templatetags'))
 sys.path.append(os.path.abspath('_themes'))
 
-import settings
-from django.core.management import setup_environ
-setup_environ(settings)
+from django.conf import settings
+settings.configure()
 
 
 # -- General configuration -----------------------------------------------------


### PR DESCRIPTION
- django.core.management.setup_environ has been removed in Django 1.6,
  django.conf.settings.configure is available since Django 1.4 and does
  the same
