### PR TITLE
Update crispy_forms_filters.py

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -105,7 +105,13 @@ def as_crispy_field(field, template_pack=TEMPLATE_PACK):
         raise CrispyError('|as_crispy_field got passed an invalid or inexistent field')
 
     template = get_template('%s/field.html' % template_pack)
-    c = Context({'field': field, 'form_show_errors': True, 'form_show_labels': True})
+    
+    extra_attrs = {'field': field, 'form_show_errors': True, 'form_show_labels': True}
+    
+    attrs = field.form.helper.get_attributes(template_pack=template_pack)
+    attrs.update(extra_attrs)
+    c = Context(attrs)
+    
     return template.render(c)
 
 


### PR DESCRIPTION
Not sure if that's a good place for this fix, but this solved an issue I was having.
Basically, when rendering our context doesn't have vars like error_text_inline or help_text_inline,  therefore templates/bootstrap/layout/help_text_and_errors.html (which gets included in other templates) is always rendered in the same way.
