### PR TITLE
Check for FileInput instead of ClearableFileInput

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -47,7 +47,7 @@ def is_checkboxselectmultiple(field):
 
 @register.filter
 def is_file(field):
-    return isinstance(field.field.widget, forms.ClearableFileInput)
+    return isinstance(field.field.widget, forms.FileInput)
 
 
 @register.filter


### PR DESCRIPTION
The check "is_file" (used to add form-control class in bootstrap3) fails to detect file-inputs when you test against forms.ClearableFileInput alone. Instead, as proposed here, checking against forms.FileInput (which is the base class of forms.ClearableFileInput) can cover both cases.
