### PR TITLE
Respect helper configuration when rendering Meta fields

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -324,7 +324,16 @@ class FormHelper(DynamicLayoutHandler):
                 left_fields_to_render = fields_to_render - form.rendered_fields
 
                 for field in left_fields_to_render:
-                    html += render_field(field, form, self.form_style, context)
+                    # We still respect the configuration of the helper
+                    # regarding which fields to render
+                    if (
+                        self.render_unmentioned_fields or
+                        (self.render_hidden_fields and
+                         form.fields[field].widget.is_hidden) or
+                        (self.render_required_fields and
+                         form.fields[field].widget.is_required)
+                    ):
+                        html += render_field(field, form, self.form_style, context)
 
         return mark_safe(html)
 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -8,6 +8,7 @@ from django.template.loader import get_template
 from django.utils.functional import memoize
 from django import template
 
+from crispy_forms.compatibility import string_types
 from crispy_forms.helper import FormHelper
 
 register = template.Library()
@@ -272,7 +273,7 @@ def do_uni_form(parser, token):
     # {% crispy form 'bootstrap' %}
     if (
         helper is not None and
-        isinstance(helper, basestring) and
+        isinstance(helper, string_types) and
         ("'" in helper or '"' in helper)
     ):
         template_pack = helper


### PR DESCRIPTION
We should still respect the configuration of the Helper object when rendering Meta fields, including `render_unmentioned_fields`, `render_hidden_fields`, and `render_required_fields`.
