### PR TITLE
Changed the help_text css class for bootstrap4 template

### DIFF
--- a/crispy_forms/templates/bootstrap4/layout/help_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/help_text.html
@@ -1,7 +1,7 @@
 {% if field.help_text %}
     {% if help_text_inline %}
-        <span id="hint_{{ field.auto_id }}" class="help-block">{{ field.help_text|safe }}</span>
+        <span id="hint_{{ field.auto_id }}" class="text-muted">{{ field.help_text|safe }}</span>
     {% else %}
-        <p id="hint_{{ field.auto_id }}" class="help-block">{{ field.help_text|safe }}</p>
+        <p id="hint_{{ field.auto_id }}" class="text-muted">{{ field.help_text|safe }}</p>
     {% endif %}
 {% endif %}


### PR DESCRIPTION
Hi there, 

As per bootstrap4 documentation ( http://v4-alpha.getbootstrap.com/components/forms/#help-text ) the help-text in bootstrap4 is .text-muted instead .help-block.

Regards, 

Martin
