### PR TITLE
[WIP] don't add 'form-control' class to multi value fields

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -45,6 +45,11 @@ def is_file(field):
 
 
 @register.filter
+def is_multivalue(field):
+    return isinstance(field.field.widget, forms.MultiWidget)
+
+
+@register.filter
 def classes(field):
     """
     Returns CSS classes of a field
@@ -118,6 +123,7 @@ class CrispyFieldNode(template.Node):
                 template_pack in ['bootstrap3', 'bootstrap4']
                 and not is_checkbox(field)
                 and not is_file(field)
+                and not is_multivalue(field)
             ):
                 css_class += ' form-control'
 

--- a/crispy_forms/tests/forms.py
+++ b/crispy_forms/tests/forms.py
@@ -121,3 +121,7 @@ class TestFormWithMedia(forms.Form):
     class Media:
         css = {'all': ('test.css',)}
         js = ('test.js',)
+
+
+class TestFormWithMultiValueField(forms.Form):
+    multi = forms.SplitDateTimeField()

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -18,7 +18,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from .compatibility import get_template_from_string
 from .conftest import only_uni_form, only_bootstrap3, only_bootstrap4, only_bootstrap
-from .forms import TestForm, TestFormWithMedia
+from .forms import TestForm, TestFormWithMedia, TestFormWithMultiValueField
 from crispy_forms.bootstrap import (
     FieldWithButtons, PrependedAppendedText, AppendedText, PrependedText,
     StrictButton
@@ -721,3 +721,21 @@ def test_bootstrap4_template_pack():
     html = render_crispy_form(form)
     assert 'form-control' not in html
     assert 'ctrlHolder' in html
+
+
+@only_bootstrap3
+def test_bootstrap3_does_add_form_control_class_to_non_multivaluefield():
+    form = TestForm()
+    form.helper = FormHelper()
+    form.helper.template_pack = 'bootstrap3'
+    html = render_crispy_form(form)
+    assert 'form-control' in html
+
+
+@only_bootstrap3
+def test_bootstrap3_does_not_add_form_control_class_to_multivaluefield():
+    form = TestFormWithMultiValueField()
+    form.helper = FormHelper()
+    form.helper.template_pack = 'bootstrap3'
+    html = render_crispy_form(form)
+    assert 'form-control' not in html


### PR DESCRIPTION
the field might contain checkboxes, and we wouldn't want to add the
form-control class to checkboxes, so it is not safe to add the class to
multi value fields.
