### PR TITLE
Fixes #478 bug about missing multifield template in bootstrap3

### DIFF
--- a/crispy_forms/templates/bootstrap3/layout/multifield.html
+++ b/crispy_forms/templates/bootstrap3/layout/multifield.html
@@ -1,27 +1,25 @@
-{% load crispy_forms_field %}
+<div {% if multifield.css_id or errors %}id="{{ multifield.css_id }}"{% endif %}
+    {% if multifield.css_class %}class="{{ multifield.css_class }}"{% endif %}
+    {{ multifield.flat_attrs|safe }}>
 
-{% if field.is_hidden %}
-    {{ field }}
-{% else %}
-
-    {% if field.label %}
-        <label for="{{ field.id_for_label }}"{% if labelclass %} class="{{ labelclass }}"{% endif %}>
+    {% if form_show_errors %}
+        <div class="alert alert-danger" role="alert">
+        {% for field in multifield.bound_fields %}
+            {% if field.errors %}
+                {% for error in field.errors %}
+                    <p id="error_{{ forloop.counter }}_{{ field.auto_id }}">{{ error }}</p>
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+        </div>
     {% endif %}
 
-    {% if field|is_checkbox %}
-        {% crispy_field field %}
+    {% if multifield.label_html %}
+        <p {% if multifield.label_class %}class="{{ multifield.label_class }}"{% endif %}>{{ multifield.label_html|safe }}</p>
     {% endif %}
 
-    {% if field.label %}
-        {{ field.label }}
-    {% endif %}
+    <div class="multiField">
+        {{ fields_output|safe }}
+    </div>
 
-    {% if not field|is_checkbox %}
-        {% crispy_field field %}
-    {% endif %}
-
-    {% if field.label %}
-        </label>
-    {% endif %}
-
-{% endif %}
+</div>

--- a/crispy_forms/templates/bootstrap3/multifield.html
+++ b/crispy_forms/templates/bootstrap3/multifield.html
@@ -1,0 +1,39 @@
+{% load crispy_forms_field %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+
+    {% if field|is_checkbox %}
+        {% if field.errors %}<div class="has-error">{% endif %}
+        <div class="checkbox">
+            {% if field.label %}
+                <label for="{{ field.id_for_label }}"{% if labelclass %} class="{{ labelclass }}"{% endif %}>
+            {% endif %}
+            
+            {% crispy_field field %}
+            {{ field.label }}
+            
+            {% if field.label %}
+                </label>
+            {% endif %}
+            {% if field.help_text %}
+                <p id="help_{{ field.auto_id }}" class="help-block">{{ field.help_text|safe }}</span>
+            {% endif %}
+        </div>
+        {% if field.errors %}</div>{% endif %}
+    {% else %}
+        <div class="form-group {% if field.errors %}has-error{% endif %}">
+            {% if field.label %}
+                <label class="control-label" for="{{ field.id_for_label }}"{% if labelclass %} class="{{ labelclass }}"{% endif %}>
+                {{ field.label }}
+                </label>
+            {% endif %}
+            {% crispy_field field %}
+            {% if field.help_text %}
+                <span id="help_{{ field.auto_id }}" class="help-block">{{ field.help_text|safe }}</span>
+            {% endif %}
+        </div>
+    {% endif %}
+
+{% endif %}


### PR DESCRIPTION
Closes #478 

Hi!
We're using a MultiField with django-crispy-forms v.1.5.2 and were getting error **bootstrap3/multifield.html cannot be found** similar to #428 or #515 (which are more specific than #478 which also encompasses ButtonHolder).
We discovered that _bootstrap3/multifield.html_ was missing, and that there was a b_ootstrap3/layout/multifield.html_ file present. 
But that _bootstrap3/layout/multifield.html_, compared to uni_form's, was similar to https://github.com/maraujop/django-crispy-forms/blob/1.5.2/crispy_forms/templates/uni_form/multifield.html and really intended for the field only. 
So we moved it to _bootstrap3/multifield.html_ and gave it bootstrap markup.
We also created a _bootstrap3/layout/multifield.html_ based on uni-form's https://github.com/maraujop/django-crispy-forms/blob/1.5.2/crispy_forms/templates/uni_form/layout/multifield.html and also adapted for bootstrap.
Finally, we suppose that the same would be needed in boostrap (v2) folder as this only fixes bootstrap3.
