### PR TITLE
Check for FileInput instead of ClearableFileInput

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -41,7 +41,7 @@ def is_checkboxselectmultiple(field):
 
 @register.filter
 def is_file(field):
-    return isinstance(field.field.widget, forms.ClearableFileInput)
+    return isinstance(field.field.widget, forms.FileInput)
 
 
 @register.filter


### PR DESCRIPTION
I'm reopening #356 as `form-control` CSS class is added to file inputs if they are not clearable

In the previous pull-request, tests seem to have fail due to another issue...
