### PR TITLE
Use helper of field form in `as_crispy_field` filter.

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -110,8 +110,19 @@ def as_crispy_field(field, template_pack=TEMPLATE_PACK):
     if not isinstance(field, forms.BoundField) and settings.DEBUG:
         raise CrispyError('|as_crispy_field got passed an invalid or inexistent field')
 
-    template = get_template('%s/field.html' % template_pack)
-    c = Context({'field': field, 'form_show_errors': True, 'form_show_labels': True})
+    attributes = {'form_show_errors': True, 'form_show_labels': True}
+    helper = getattr(field.form, 'helper', None)
+    template_path = None
+    if helper is not None:
+        attributes.update(helper.get_attributes(template_pack))
+        template_path = helper.field_template
+
+    if not template_path:
+        template_path = '%s/field.html' % template_pack
+
+    attributes['field'] = field
+    template = get_template(template_path)
+    c = Context(attributes)
 
     if django.VERSION >= (1, 8):
         c = c.flatten()


### PR DESCRIPTION
While trying to satisfy my usecase i stumbled upon [this](https://github.com/maraujop/django-crispy-forms/issues/96) issue where @rafalp expressed desire to be able to use helpers with `as_crispy_field` filter. Two years later here i am implementing this functionality. It also uses `helper.field_template` if one is set.
