### PR TITLE
Fix passing `extra_context` argument to PrependedAppendedText.render()

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -30,12 +30,13 @@ class PrependedAppendedText(Field):
         super(PrependedAppendedText, self).__init__(field, *args, **kwargs)
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, extra_context=None, **kwargs):
-        extra_context = {
+        extra_context = extra_context.copy() if extra_context is not None else {}
+        extra_context.update({
             'crispy_appended_text': self.appended_text,
             'crispy_prepended_text': self.prepended_text,
             'input_size': self.input_size,
             'active': getattr(self, "active", False)
-        }
+        })
         if hasattr(self, 'wrapper_class'):
             extra_context['wrapper_class'] = self.wrapper_class
         template = self.get_template_name(template_pack)


### PR DESCRIPTION
The `extra_context` argument is ignored in `PrependedAppendedText.render()`. This fix makes sure both dictionaries are merged, but don't affect each other.
