### PR TITLE
Avoid risk for editing shared state via `self.attrs`.

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -416,6 +416,9 @@ class Field(LayoutObject):
 
         if not hasattr(self, 'attrs'):
             self.attrs = {}
+        else:
+            # Make sure shared state is not edited.
+            self.attrs = self.attrs.copy()
 
         if 'css_class' in kwargs:
             if 'class' in self.attrs:


### PR DESCRIPTION
The code check in `Field.__init__()` checks whether `self.attrs` is already set. However, this assumes that `hasattr()` resolves an object-level variable, assigned by a super `__init__()`. Potentially `attrs` can be defined as class variable, causing it to be shared between multiple `Field` instances.

While this likely didn't happen yet, I'd rather be on the safe side here. (in fact I did experience some shared state for the `help_text` before)
