### PR TITLE
Fix documentation for `Accordion` layout object

### DIFF
--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -279,7 +279,7 @@ These ones live under module ``crispy_forms.bootstrap``.
         AccordionGroup('First Group',
             'radio_buttons'
         ),
-        Tab('Second Group',
+        AccordionGroup('Second Group',
             Field('field_name_3', css_class="extra")
         )
     )


### PR DESCRIPTION
`AccordionGroup` must exist within `Accordion` layout object.
