### PR TITLE
Bootstrap 4 improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ env:
   - DJANGO='django>=1.9.0,<1.10.0'
   - DJANGO='django>=1.10.0,<1.11.0'
   - DJANGO='https://github.com/django/django/archive/master.tar.gz'
+before_install:
+  - pip install --upgrade pytest
 install:
   - pip install $DJANGO
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - DJANGO='django>=1.10.0,<1.11.0'
   - DJANGO='https://github.com/django/django/archive/master.tar.gz'
 before_install:
-  - pip install --upgrade pytest
+  - pip install --upgrade 'pytest<3.0.0'
 install:
   - pip install $DJANGO
   - pip install -e .

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -358,13 +358,6 @@ class FormHelper(DynamicLayoutHandler):
             except:
                 pass
 
-        if template_pack == 'bootstrap4':
-            grid_colum_matcher = re.compile('\w*col-(xs|sm|md|lg|xl)-\d+\w*')
-            using_grid_layout = (grid_colum_matcher.match(self.label_class) or
-                                 grid_colum_matcher.match(self.field_class))
-            if using_grid_layout:
-                items['using_grid_layout'] = True
-
         items['attrs'] = {}
         if self.attrs:
             items['attrs'] = self.attrs.copy()

--- a/crispy_forms/templates/bootstrap4/field.html
+++ b/crispy_forms/templates/bootstrap4/field.html
@@ -6,7 +6,7 @@
     {% if field|is_checkbox %}
         <div class="form-group">
         {% if label_class %}
-            <div class="controls col-{{ bootstrap_device_type }}-offset-{{ label_size }} {{ field_class }}">
+            <div class="col-{{ bootstrap_device_type }}-offset-{{ label_size }} {{ field_class }}">
         {% endif %}
     {% endif %}
     <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-danger{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
@@ -32,7 +32,7 @@
                     {% include 'bootstrap4/layout/help_text_and_errors.html' %}
                 </label>
             {% else %}
-                <div class="controls {{ field_class }}">
+                <div class="{{ field_class }}">
                     {% crispy_field field %}
                     {% include 'bootstrap4/layout/help_text_and_errors.html' %}
                 </div>

--- a/crispy_forms/templates/bootstrap4/field.html
+++ b/crispy_forms/templates/bootstrap4/field.html
@@ -4,12 +4,12 @@
     {{ field }}
 {% else %}
     {% if field|is_checkbox %}
-        <div class="form-group{% if using_grid_layout %} row{% endif %}">
+        <div class="form-group">
         {% if label_class %}
             <div class="controls col-{{ bootstrap_device_type }}-offset-{{ label_size }} {{ field_class }}">
         {% endif %}
     {% endif %}
-    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% if using_grid_layout %} row{% endif %}{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-danger{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-danger{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
         {% if field.label and not field|is_checkbox and form_show_labels %}
             <label for="{{ field.id_for_label }}" class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}

--- a/crispy_forms/templates/bootstrap4/inputs.html
+++ b/crispy_forms/templates/bootstrap4/inputs.html
@@ -1,10 +1,10 @@
 {% if inputs %}
     <div class="form-group">
         {% if label_class %}
-            <div class="aab controls {{ label_class }}"></div>
+            <div class="aab {{ label_class }}"></div>
         {% endif %}
 
-        <div class="controls {{ field_class }}">
+        <div class="{{ field_class }}">
             {% for input in inputs %}
                 {% include "bootstrap4/layout/baseinput.html" %}
             {% endfor %}

--- a/crispy_forms/templates/bootstrap4/inputs.html
+++ b/crispy_forms/templates/bootstrap4/inputs.html
@@ -1,5 +1,5 @@
 {% if inputs %}
-    <div class="form-group{% if using_grid_layout %} row{% endif %}">
+    <div class="form-group">
         {% if label_class %}
             <div class="aab controls {{ label_class }}"></div>
         {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<div class="controls {{ field_class }}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+<div class="{{ field_class }}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
     {% include 'bootstrap4/layout/field_errors_block.html' %}
 
     {% for choice in field.field.choices %}

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
@@ -1,7 +1,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
             <label for="{{ field.auto_id }}"  class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
@@ -1,7 +1,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if using_grid_layout %} row{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
             <label for="{{ field.auto_id }}"  class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -7,7 +7,7 @@
         </label>
     {% endif %}
 
-    <div class="controls {{ field_class }}">
+    <div class="{{ field_class }}">
         <div class="input-group">
             {% crispy_field field %}
             <span class="input-group-btn{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ buttons|safe }}</span>

--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -1,6 +1,6 @@
 {% load crispy_forms_field %}
 
-<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
+<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
     {% if field.label and form_show_labels %}
         <label for="{{ field.id_for_label }}" class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
             {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -1,6 +1,6 @@
 {% load crispy_forms_field %}
 
-<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if using_grid_layout %} row{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
+<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
     {% if field.label and form_show_labels %}
         <label for="{{ field.id_for_label }}" class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
             {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/formactions.html
+++ b/crispy_forms/templates/bootstrap4/layout/formactions.html
@@ -1,4 +1,4 @@
-<div{% if formactions.attrs %} {{ formactions.flat_attrs|safe }}{% endif %} class="form-group{% if using_grid_layout %} row{% endif %}">
+<div{% if formactions.attrs %} {{ formactions.flat_attrs|safe }}{% endif %} class="form-group">
     {% if label_class %}
         <div class="aab controls {{ label_class }}"></div>
     {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/formactions.html
+++ b/crispy_forms/templates/bootstrap4/layout/formactions.html
@@ -1,9 +1,9 @@
 <div{% if formactions.attrs %} {{ formactions.flat_attrs|safe }}{% endif %} class="form-group">
     {% if label_class %}
-        <div class="aab controls {{ label_class }}"></div>
+        <div class="aab {{ label_class }}"></div>
     {% endif %}
 
-    <div class="controls {{ field_class }}">
+    <div class="{{ field_class }}">
         {{ fields_output|safe }}
     </div>
 </div>

--- a/crispy_forms/templates/bootstrap4/layout/inline_field.html
+++ b/crispy_forms/templates/bootstrap4/layout/inline_field.html
@@ -11,7 +11,7 @@
             </label>
         </div>
     {% else %}
-        <div id="div_{{ field.auto_id }}" class="form-group{% if using_grid_layout %} row{% endif %}">
+        <div id="div_{{ field.auto_id }}" class="form-group">
             <label for="{{ field.id_for_label }}" class="sr-only{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}
             </label>

--- a/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if using_grid_layout %} row{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label and form_show_labels %}
             <label for="{{ field.id_for_label }}" class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
@@ -11,7 +11,7 @@
             </label>
         {% endif %}
 
-        <div class="controls {{ field_class }}">
+        <div class="{{ field_class }}">
             {% if field|is_select %}
                 {% if crispy_prepended_text %}<span class="input-group{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_prepended_text|safe }}</span>{% endif %}
                 {% crispy_field field %}

--- a/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label and form_show_labels %}
             <label for="{{ field.id_for_label }}" class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<div class="controls {{ field_class }}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+<div class="{{ field_class }}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
     {% include 'bootstrap4/layout/field_errors_block.html' %}
 
     {% for choice in field.field.choices %}

--- a/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
@@ -1,7 +1,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if using_grid_layout %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
             <label for="{{ field.auto_id }}"  class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/uneditable_input.html
+++ b/crispy_forms/templates/bootstrap4/layout/uneditable_input.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_field %}
 
 
-<div id="div_{{ field.auto_id }}" class="form-group{% if using_grid_layout %} row{% endif %}{% if form_show_errors and field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+<div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
     <label class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}</label>
     <div class="controls {{ field_class }}">
         {% crispy_field field 'disabled' 'disabled' %}

--- a/crispy_forms/templates/bootstrap4/layout/uneditable_input.html
+++ b/crispy_forms/templates/bootstrap4/layout/uneditable_input.html
@@ -3,7 +3,7 @@
 
 <div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
     <label class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}</label>
-    <div class="controls {{ field_class }}">
+    <div class="{{ field_class }}">
         {% crispy_field field 'disabled' 'disabled' %}
         {% include 'bootstrap4/layout/help_text.html' %}
     </div>

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -755,18 +755,14 @@ def test_template_pack():
 
 
 @only_bootstrap4
-def test_bootstrap4_label_class_and_field_class():
+def test_label_class_and_field_class():
     form = TestForm()
     form.helper = FormHelper()
-    html = render_crispy_form(form)
-
-    assert '<div class="form-group">' in html
-
     form.helper.label_class = 'col-lg-2'
     form.helper.field_class = 'col-lg-8'
     html = render_crispy_form(form)
 
-    assert '<div class="form-group row">' in html
+    assert '<div class="form-group">' in html
     assert '<div class="controls col-lg-offset-2 col-lg-8">' in html
     assert html.count('col-lg-8') == 7
 
@@ -774,13 +770,13 @@ def test_bootstrap4_label_class_and_field_class():
     form.helper.field_class = 'col-sm-8'
     html = render_crispy_form(form)
 
-    assert '<div class="form-group row">' in html
+    assert '<div class="form-group">' in html
     assert '<div class="controls col-sm-offset-3 col-sm-8">' in html
     assert html.count('col-sm-8') == 7
 
 
 @only_bootstrap4
-def test_bootstrap4_template_pack():
+def test_template_pack():
     form = TestForm()
     form.helper = FormHelper()
     form.helper.template_pack = 'uni_form'

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -763,7 +763,7 @@ def test_label_class_and_field_class():
     html = render_crispy_form(form)
 
     assert '<div class="form-group">' in html
-    assert '<div class="controls col-lg-offset-2 col-lg-8">' in html
+    assert '<div class="col-lg-offset-2 col-lg-8">' in html
     assert html.count('col-lg-8') == 7
 
     form.helper.label_class = 'col-sm-3'
@@ -771,7 +771,7 @@ def test_label_class_and_field_class():
     html = render_crispy_form(form)
 
     assert '<div class="form-group">' in html
-    assert '<div class="controls col-sm-offset-3 col-sm-8">' in html
+    assert '<div class="col-sm-offset-3 col-sm-8">' in html
     assert html.count('col-sm-8') == 7
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -39,6 +39,7 @@ Since version 1.1.0, django-crispy-forms has built-in support for different CSS 
 
 * ``bootstrap`` `Bootstrap`_ is crispy-forms's default template pack, version 2 of the popular simple and flexible HTML, CSS, and Javascript for user interfaces from Twitter.
 * ``bootstrap3`` Twitter Bootstrap version 3.
+* ``bootstrap4`` Alpha support for Twitter Bootstrap version 4, which is still in Alpha.
 * ``uni-form`` `Uni-form`_ is a nice looking, well structured, highly customizable, accessible and usable forms.
 * ``foundation`` `Foundation`_ In the creator's words, "The most advanced responsive front-end framework in the world." This template pack is externally available through `crispy-forms-foundation`_
 


### PR DESCRIPTION
- Revert "Only add 'row' to 'form-group' if grid layout"
  This reverts commit [4bee0fd](https://github.com/maraujop/django-crispy-forms/commit/4bee0fda29dc6a98162856e446a5871aebc5cfb8).
  Closes https://github.com/maraujop/django-crispy-forms/issues/613


- Drop `control` CSS group since it was deprecated. (We can also drop it everywhere it is used in the Bootstrap 3 templates, but people might be relying on it for custom CSS themselves)