### PR TITLE
Fix missing _active_originaly_included #526.

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -245,7 +245,7 @@ class ContainerHolder(Div):
         target = self.first_container_with_errors(form.errors.keys())
         if target is None:
             target = self.fields[0]
-            if not target._active_originally_included:
+            if not getattr(target, '_active_originally_included', None):
                 target.active = True
             return target
 


### PR DESCRIPTION
Closes https://github.com/django-crispy-forms/django-crispy-forms/issues/526