### PR TITLE
Form level group wrapper classes makes horizontal forms DRYer

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -135,6 +135,9 @@ class FormHelper(DynamicLayoutHandler):
             to form class attribute. The form will always have by default
             'uniForm' class.
 
+        **form_group_wrapper_class**: String containing separated CSS classes to be applied
+            to each row of inputs.
+
         **form_tag**: It specifies if <form></form> tags should be rendered when using a Layout.
             If set to False it renders the form without the <form></form> tags. Defaults to True.
 
@@ -189,6 +192,7 @@ class FormHelper(DynamicLayoutHandler):
     form = None
     form_id = ''
     form_class = ''
+    form_group_wrapper_class = ''
     layout = None
     form_tag = True
     form_error_title = None
@@ -374,6 +378,8 @@ class FormHelper(DynamicLayoutHandler):
         else:
             if template_pack == 'uni_form':
                 items['attrs']['class'] = self.attrs.get('class', '') + " uniForm"
+        if self.form_group_wrapper_class:
+            items['attrs']['form_group_wrapper_class'] = self.form_group_wrapper_class
 
         items['flat_attrs'] = flatatt(items['attrs'])
 

--- a/crispy_forms/templates/bootstrap4/field.html
+++ b/crispy_forms/templates/bootstrap4/field.html
@@ -9,7 +9,7 @@
             <div class="col-{{ bootstrap_device_type }}-offset-{{ label_size }} {{ field_class }}">
         {% endif %}
     {% endif %}
-    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-danger{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_group_wrapper_class %} {{ form_group_wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-danger{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
         {% if field.label and not field|is_checkbox and form_show_labels %}
             <label for="{{ field.id_for_label }}" class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}

--- a/crispy_forms/templates/bootstrap4/inputs.html
+++ b/crispy_forms/templates/bootstrap4/inputs.html
@@ -1,5 +1,5 @@
 {% if inputs %}
-    <div class="form-group">
+    <div class="form-group{% if form_group_wrapper_class %} {{ form_group_wrapper_class }}{% endif %}">
         {% if label_class %}
             <div class="aab {{ label_class }}"></div>
         {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_group_wrapper_class %} {{ form_group_wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label and form_show_labels %}
             <label for="{{ field.id_for_label }}" class="form-control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">


### PR DESCRIPTION
So I should've done what @yunti originally recommended on #613 

This tidies this up horizontal forms a lot:

```
-        Field('text_input', css_class='form-control-lg', wrapper_class='row'),
-        Field('textarea', rows="3", css_class='form-control-lg', wrapper_class='row'),
-        Field('radio_buttons', wrapper_class='row'),
-        Field('checkboxes', style="background: #FAFAFA", wrapper_class='row'),
-        AppendedText('appended_text', '.00', wrapper_class='row'),
-        AppendedText('appended_text2', '.00', css_class='form-control-lg', wrapper_class='row'),
+        Field('text_input', css_class='form-control-lg'),
+        Field('textarea', rows="3", css_class='form-control-lg'),
+        Field('radio_buttons'),
+        Field('checkboxes', style="background: #FAFAFA"),
+        AppendedText('appended_text', '.00'),
+        AppendedText('appended_text2', '.00', css_class='form-control-lg'),
         PrependedText('prepended_text',
                       '<input type="checkbox" checked="checked" value="" id="" name="">',
-                      active=True, wrapper_class='row'),
-        PrependedText('prepended_text_two', '@', wrapper_class='row'),
-        Field('multicolon_select', wrapper_class='row'),
-        Div(
-            Div(
-                Submit('save_changes', 'Save changes', css_class="btn-primary"),
-                Submit('cancel', 'Cancel'),
-                css_class='offset-sm-4 col-sm-8'
-            ),
-            css_class='form-group row'
-        )
+                      active=True),
+        PrependedText('prepended_text_two', '@'),
+        Field('multicolon_select'),
     )

+    helper.add_input(Submit('submit', 'Save', css_class='btn-primary'))
+    helper.add_input(Submit('cancel', 'Cancel'))
+
+    helper.form_group_wrapper_class = 'row'
```

It means we don't need to set a wrapper_class for every field, and were going to add a `wrapper_class` to `Submit` inputs, but don't need that either. The current workaround was using a custom layout and putting a `Div` inside another `Div` for the `form-group row` and offsets.

At the moment we're using both `form_group_wrapper_class` and `wrapper_class` on each field, so certain fields can add to the classes. I'm not sure if there are cases where someone might want to override `form_group_wrapper_class` with `wrapper_class`.
