### PR TITLE
Error message class for Bootstrap 4

### DIFF
--- a/crispy_forms/templates/bootstrap4/layout/field_errors.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_errors.html
@@ -1,5 +1,5 @@
 {% if form_show_errors and field.errors %}
     {% for error in field.errors %}
-        <span id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="help-block"><strong>{{ error }}</strong></span>
+        <span id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="form-control-feedback"><strong>{{ error }}</strong></span>
     {% endfor %}
 {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/field_errors_block.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_errors_block.html
@@ -1,5 +1,5 @@
 {% if form_show_errors and field.errors %}
     {% for error in field.errors %}
-        <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="help-block"><strong>{{ error }}</strong></p>
+        <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="form-control-feedback"><strong>{{ error }}</strong></p>
     {% endfor %}
 {% endif %}

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -677,7 +677,7 @@ def test_error_and_help_inline():
 
     # Check that help goes before error, otherwise CSS won't work
     help_position = html.find('<span id="hint_id_email" class="help-inline">')
-    error_position = html.find('<p id="error_1_id_email" class="help-block">')
+    error_position = html.find('<p id="error_1_id_email" class="form-control-feedback">')
     assert help_position < error_position
 
     # Viceversa


### PR DESCRIPTION
Bootstrap 4 uses form-control-feedback instead of help-block.