### PR TITLE
Fix form helper tests

### DIFF
--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -744,14 +744,14 @@ def test_label_class_and_field_class():
     form.helper.field_class = 'col-lg-8'
     html = render_crispy_form(form)
 
-    assert '<div class="form-group"> <div class="controls col-lg-offset-2 col-lg-8"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput checkbox" id="id_is_company" name="is_company" type="checkbox" />'
+    assert '<div class="form-group"> <div class="controls col-lg-offset-2 col-lg-8"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput" id="id_is_company" name="is_company" type="checkbox" />' in html
     assert html.count('col-lg-8') == 7
 
     form.helper.label_class = 'col-sm-3'
     form.helper.field_class = 'col-sm-8'
     html = render_crispy_form(form)
 
-    assert '<div class="form-group"> <div class="controls col-sm-offset-3 col-sm-8"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput checkbox" id="id_is_company" name="is_company" type="checkbox" />'
+    assert '<div class="form-group"> <div class="controls col-sm-offset-3 col-sm-8"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput" id="id_is_company" name="is_company" type="checkbox" />' in html
     assert html.count('col-sm-8') == 7
 
 
@@ -766,7 +766,7 @@ def test_template_pack():
 
 
 @only_bootstrap4
-def test_label_class_and_field_class():
+def test_label_class_and_field_class_bs4():
     form = TestForm()
     form.helper = FormHelper()
     form.helper.label_class = 'col-lg-2'
@@ -787,7 +787,7 @@ def test_label_class_and_field_class():
 
 
 @only_bootstrap4
-def test_template_pack():
+def test_template_pack_bs4():
     form = TestForm()
     form.helper = FormHelper()
     form.helper.template_pack = 'uni_form'


### PR DESCRIPTION
Rename tests for bootstrap4 because they clash with tests for bootstrap3.
Fix asserts so they actually assert that string presents in the html.
