### PR TITLE
Use get_bound_field for fields defining a custom BoundField

### DIFF
--- a/crispy_forms/tests/test_utils.py
+++ b/crispy_forms/tests/test_utils.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from crispy_forms.utils import list_union, list_difference, list_intersection, set_hidden, render_field
-
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout
+import django
+from django import forms
+from django.template.base import Context, Template
+import pytest
 
 def test_list_intersection():
     assert list_intersection([1, 3], [2, 3]) == [3]
@@ -37,3 +42,32 @@ def test_set_hidden():
 def test_render_field_with_none_field():
     rendered = render_field(field=None, form=None, form_style=None, context=None)
     assert rendered == ''
+
+@pytest.mark.skipif(django.VERSION < (1, 9),
+                    reason="Custom BoundField behavior is was introduced in 1.9.")
+def test_custom_bound_field():
+    from django.forms.boundfield import BoundField
+
+    extra = 'xyxyxyxyxyx'
+
+    class CustomBoundField(BoundField):
+        @property
+        def auto_id(self):
+            return extra
+
+    class MyCharField(forms.CharField):
+        def get_bound_field(self, form, field_name):
+            return CustomBoundField(form, self, field_name)
+
+    class MyForm(forms.Form):
+        f = MyCharField()
+
+        def __init__(self, *args, **kwargs):
+            super(MyForm, self).__init__(*args, **kwargs)
+            self.helper = FormHelper()
+            self.helper.layout = Layout('f')
+
+    template = Template('{% load crispy_forms_tags %}\n{% crispy form "bootstrap3" %}')
+    rendered = template.render(Context({'form': MyForm(data={'f': 'something'})}))
+
+    assert extra in rendered

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -89,7 +89,8 @@ def render_field(
 
         try:
             # Injecting HTML attributes into field's widget, Django handles rendering these
-            field_instance = form.fields[field]
+            bound_field = form[field]
+            field_instance = bound_field.field
             if attrs is not None:
                 widgets = getattr(field_instance.widget, 'widgets', [field_instance.widget])
 
@@ -131,8 +132,6 @@ def render_field(
         if field_instance is None:
             html = ''
         else:
-            bound_field = BoundField(form, field_instance, field)
-
             if template is None:
                 if form.crispy_field_template is None:
                     template = default_field_template(template_pack)


### PR DESCRIPTION
Django 1.9 introduced a useful feature where fields can [define custom `BoundField` behavior](https://docs.djangoproject.com/en/1.10/ref/forms/api/#customizing-boundfield). This PR updates the `render_field` utility method to obtain the bound field from [the form's `__getitem__` method](https://github.com/django/django/blob/1.10/django/forms/forms.py#L141-L155), instead of manually constructing a plain `BoundField` instance for the field.

## Testing

I wrote a test in `test_utils.py`. I verified that it failed before updating the bound field behavior, and passed afterwards.