### PR TITLE
Support several bootstrap sizes in label_class for checkbox input

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -348,15 +348,9 @@ class FormHelper(DynamicLayoutHandler):
             'field_class': self.field_class,
             'include_media': self.include_media
         }
-        # col-[lg|md|sm|xs]-<number>
-        label_size_match = re.search('(\d+)', self.label_class)
-        device_type_match = re.search('(lg|md|sm|xs)', self.label_class)
-        if label_size_match and device_type_match:
-            try:
-                items['label_size'] = int(label_size_match.groups()[0])
-                items['bootstrap_device_type'] = device_type_match.groups()[0]
-            except:
-                pass
+        bootstrap_size_match = re.findall('col-(lg|md|sm|xs)-(\d+)', self.label_class)
+        if bootstrap_size_match:
+            items['bootstrap_checkbox_offsets'] = ['col-%s-offset-%s' % m for m in bootstrap_size_match]
 
         items['attrs'] = {}
         if self.attrs:

--- a/crispy_forms/templates/bootstrap3/field.html
+++ b/crispy_forms/templates/bootstrap3/field.html
@@ -6,7 +6,7 @@
     {% if field|is_checkbox %}
         <div class="form-group">
         {% if label_class %}
-            <div class="controls col-{{ bootstrap_device_type }}-offset-{{ label_size }} {{ field_class }}">
+            <div class="controls {% for offset in bootstrap_checkbox_offsets %}{{ offset }} {% endfor %}{{ field_class }}">
         {% endif %}
     {% endif %}
     <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">

--- a/crispy_forms/templates/bootstrap4/field.html
+++ b/crispy_forms/templates/bootstrap4/field.html
@@ -6,7 +6,7 @@
     {% if field|is_checkbox %}
         <div class="form-group">
         {% if label_class %}
-            <div class="col-{{ bootstrap_device_type }}-offset-{{ label_size }} {{ field_class }}">
+            <div class="{% for offset in bootstrap_checkbox_offsets %}{{ offset }} {% endfor %}{{ field_class }}">
         {% endif %}
     {% endif %}
     <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-danger{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -184,7 +184,6 @@ class BasicNode(template.Node):
             'flat_attrs': attrs.get('flat_attrs', ''),
             'error_text_inline': attrs.get('error_text_inline', True),
             'label_class': attrs.get('label_class', ''),
-            'label_size': attrs.get('label_size', 0),
             'field_class': attrs.get('field_class', ''),
             'include_media': attrs.get('include_media', True),
         }

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -747,11 +747,11 @@ def test_label_class_and_field_class():
     assert '<div class="form-group"> <div class="controls col-lg-offset-2 col-lg-8"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput" id="id_is_company" name="is_company" type="checkbox" />' in html
     assert html.count('col-lg-8') == 7
 
-    form.helper.label_class = 'col-sm-3'
-    form.helper.field_class = 'col-sm-8'
+    form.helper.label_class = 'col-sm-3 col-md-4'
+    form.helper.field_class = 'col-sm-8 col-md-6'
     html = render_crispy_form(form)
 
-    assert '<div class="form-group"> <div class="controls col-sm-offset-3 col-sm-8"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput" id="id_is_company" name="is_company" type="checkbox" />' in html
+    assert '<div class="form-group"> <div class="controls col-sm-offset-3 col-md-offset-4 col-sm-8 col-md-6"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput" id="id_is_company" name="is_company" type="checkbox" />' in html
     assert html.count('col-sm-8') == 7
 
 
@@ -777,12 +777,12 @@ def test_label_class_and_field_class_bs4():
     assert '<div class="col-lg-offset-2 col-lg-8">' in html
     assert html.count('col-lg-8') == 7
 
-    form.helper.label_class = 'col-sm-3'
-    form.helper.field_class = 'col-sm-8'
+    form.helper.label_class = 'col-sm-3 col-md-4'
+    form.helper.field_class = 'col-sm-8 col-md-6'
     html = render_crispy_form(form)
 
     assert '<div class="form-group">' in html
-    assert '<div class="col-sm-offset-3 col-sm-8">' in html
+    assert '<div class="col-sm-offset-3 col-md-offset-4 col-sm-8 col-md-6">' in html
     assert html.count('col-sm-8') == 7
 
 


### PR DESCRIPTION
For checkbox input label is displayed after the input
so the input have to be aligned with the rest of the form
using col-<device>-offset-<size> class. But sometimes form may have
different sizes on different devices so we have to build offsets
for each pair of device and size.

I'm not sure about removing label_size and bootstrap_device_type attrs but right now they are only used in the case of bootstrap checkbox.