### PR TITLE
Prevent adding names to inputs when the former are None

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -176,7 +176,8 @@ class BaseInput(TemplateNameMixin):
     template = "%s/layout/baseinput.html"
 
     def __init__(self, name, value, **kwargs):
-        self.name = name
+        if name is not None:
+            self.name = name
         self.value = value
         self.id = kwargs.pop('css_id', '')
         self.attrs = {}

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -435,6 +435,7 @@ def test_layout_composition():
             ),
             ButtonHolder(
                 Submit('Save', 'Save', css_class='button white'),
+                Submit(None, 'Submit'),
             ),
             Div(
                 'password1',
@@ -463,6 +464,7 @@ def test_layout_composition():
     assert 'id="custom-div"' in html
     assert 'class="customdivs"' in html
     assert 'last_name' not in html
+    assert 'name="None"' not in html
 
 
 @only_uni_form


### PR DESCRIPTION
There is a small inconvenience: when a person adds a button using the class `Submit`, one is forced to give a name to it.

But often there is no need for a name. And I think, the person will choose assignment `None` as a name then.

But when one cooses the variant, a name is assigned anyway and it's `None`.

Consequently when the form is submited data which is sent to a server looks like:
`csrfmiddlewaretoken:EHE435eIo9sWz3EGdeB7ibHVz0sf3mItjD0bFfOljC07uk7oEN5ePiZ6NNFFHFKv`
`...`
`None:Submit`

I've tried to fix it by creating this pull request.