### PR TITLE
Remove useless checks in code

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -3,7 +3,6 @@ try:
 except ImportError:
     izip = zip
 
-import django
 from django import forms
 from django import template
 from django.template import loader, Context
@@ -183,7 +182,6 @@ def crispy_addon(field, append="", prepend="", form_show_labels=True):
         if not prepend and not append:
             raise TypeError("Expected a prepend and/or append argument")
 
-        if django.VERSION >= (1, 8):
-            context = context.flatten()
+        context = context.flatten()
 
     return template.render(context)

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import django
 from django.conf import settings
 from django.forms import forms
 from django.forms.formsets import BaseFormSet
@@ -53,7 +52,7 @@ def as_crispy_form(form, template_pack=TEMPLATE_PACK, label_class="", field_clas
             'form_show_labels': True,
             'label_class': label_class,
             'field_class': field_class,
-        })
+        }).flatten()
     else:
         template = uni_form_template(template_pack)
         c = Context({
@@ -62,10 +61,7 @@ def as_crispy_form(form, template_pack=TEMPLATE_PACK, label_class="", field_clas
             'form_show_labels': True,
             'label_class': label_class,
             'field_class': field_class,
-        })
-
-    if django.VERSION >= (1, 8):
-        c = c.flatten()
+        }).flatten()
 
     return template.render(c)
 
@@ -84,13 +80,10 @@ def as_crispy_errors(form, template_pack=TEMPLATE_PACK):
     """
     if isinstance(form, BaseFormSet):
         template = get_template('%s/errors_formset.html' % template_pack)
-        c = Context({'formset': form})
+        c = Context({'formset': form}).flatten()
     else:
         template = get_template('%s/errors.html' % template_pack)
-        c = Context({'form': form})
-
-    if django.VERSION >= (1, 8):
-        c = c.flatten()
+        c = Context({'form': form}).flatten()
 
     return template.render(c)
 
@@ -111,10 +104,7 @@ def as_crispy_field(field, template_pack=TEMPLATE_PACK):
         raise CrispyError('|as_crispy_field got passed an invalid or inexistent field')
 
     template = get_template('%s/field.html' % template_pack)
-    c = Context({'field': field, 'form_show_errors': True, 'form_show_labels': True})
-
-    if django.VERSION >= (1, 8):
-        c = c.flatten()
+    c = Context({'field': field, 'form_show_errors': True, 'form_show_labels': True}).flatten()
 
     return template.render(c)
 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 from copy import copy
 
-import django
 from django.conf import settings
 from django.forms.formsets import BaseFormSet
-from django.template import Context
 from django.template.loader import get_template
 from django import template
 
@@ -211,7 +209,7 @@ def whole_uni_form_template(template_pack=TEMPLATE_PACK):
 
 class CrispyFormNode(BasicNode):
     def render(self, context):
-        c = self.get_render(context)
+        c = self.get_render(context).flatten()
 
         if self.actual_helper is not None and getattr(self.actual_helper, 'template', False):
             template = get_template(self.actual_helper.template)
@@ -220,10 +218,6 @@ class CrispyFormNode(BasicNode):
                 template = whole_uni_formset_template(self.template_pack)
             else:
                 template = whole_uni_form_template(self.template_pack)
-
-        if django.VERSION >= (1, 8):
-            c = c.flatten()
-
         return template.render(c)
 
 

--- a/crispy_forms/tests/forms.py
+++ b/crispy_forms/tests/forms.py
@@ -1,4 +1,3 @@
-import django
 from django import forms
 from django.db import models
 
@@ -96,8 +95,7 @@ class TestForm4(forms.ModelForm):
         because obviously it casts the string to a set
         """
         model = CrispyTestModel
-        if django.VERSION >= (1, 6):
-            fields = '__all__'  # eliminate RemovedInDjango18Warning
+        fields = '__all__'  # eliminate RemovedInDjango18Warning
 
 
 class TestForm5(forms.Form):

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -271,7 +271,7 @@ def test_formset_layout(settings):
     )
 
     # Check formset fields
-    hidden_count = 4  # before Django 1.7 added MIN_NUM_FORM_COUNT
+    hidden_count = 5
     assert html.count(
         'id="id_form-TOTAL_FORMS" name="form-TOTAL_FORMS" type="hidden" value="3"'
     ) == 1
@@ -281,11 +281,9 @@ def test_formset_layout(settings):
     assert html.count(
         'id="id_form-MAX_NUM_FORMS" name="form-MAX_NUM_FORMS" type="hidden" value="1000"'
     ) == 1
-    if hasattr(forms.formsets, 'MIN_NUM_FORM_COUNT'):
-        assert html.count(
-            'id="id_form-MIN_NUM_FORMS" name="form-MIN_NUM_FORMS" type="hidden" value="0"'
-        ) == 1
-        hidden_count += 1
+    assert html.count(
+        'id="id_form-MIN_NUM_FORMS" name="form-MIN_NUM_FORMS" type="hidden" value="0"'
+    ) == 1
     assert html.count("hidden") == hidden_count
 
     # Check form structure

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -2,9 +2,7 @@ from __future__ import unicode_literals
 import logging
 import sys
 
-import django
 from django.conf import settings
-from django.forms.forms import BoundField
 from django.template import Context
 from django.template.loader import get_template
 from django.utils.html import conditional_escape
@@ -155,9 +153,7 @@ def render_field(
             if extra_context is not None:
                 context.update(extra_context)
 
-            if django.VERSION >= (1, 8):
-                context = context.flatten()
-
+            context = context.flatten()
             html = template.render(context)
 
         return html
@@ -231,5 +227,3 @@ def list_difference(left, right):
             blocked.add(item)
             difference.append(item)
     return difference
-
-


### PR DESCRIPTION
`MIN_NUM_FORM_COUNT` was implemented in Django 1.7.

The check was useful when the project supported lower versions of Django.

----
Since the project does not support Django versions lower than 1.8, there is no need to check whether they are greater than 1.6 or 1.7.