### PR TITLE
Sort import statements. Remove some unused ones

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -1,13 +1,14 @@
 from __future__ import unicode_literals
+
 from random import randint
 
 from django.template import Template
-from django.template.loader import render_to_string
 from django.template.defaultfilters import slugify
+from django.template.loader import render_to_string
 
 from .compatibility import text_type
-from .layout import LayoutObject, Field, Div, TemplateNameMixin
-from .utils import render_field, flatatt, TEMPLATE_PACK
+from .layout import Div, Field, LayoutObject, TemplateNameMixin
+from .utils import TEMPLATE_PACK, flatatt, render_field
 
 
 class PrependedAppendedText(Field):

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -1,19 +1,21 @@
 # -*- coding: utf-8 -*-
 import re
 
+from django.utils.safestring import mark_safe
+
+from crispy_forms.compatibility import string_types
+from crispy_forms.exceptions import FormHelpersException
+from crispy_forms.layout import Layout
+from crispy_forms.layout_slice import LayoutSlice
+from crispy_forms.utils import (
+    TEMPLATE_PACK, flatatt, list_difference, list_intersection, render_field,
+)
+
 try:
     from django.urls import reverse, NoReverseMatch
 except ImportError:
     # Django < 1.10
     from django.core.urlresolvers import reverse, NoReverseMatch
-
-from django.utils.safestring import mark_safe
-
-from crispy_forms.compatibility import string_types
-from crispy_forms.layout import Layout
-from crispy_forms.layout_slice import LayoutSlice
-from crispy_forms.utils import render_field, flatatt, TEMPLATE_PACK, list_intersection, list_difference
-from crispy_forms.exceptions import FormHelpersException
 
 
 class DynamicLayoutHandler(object):

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -5,7 +5,9 @@ from django.template.loader import render_to_string
 from django.utils.html import conditional_escape
 
 from crispy_forms.compatibility import string_types, text_type
-from crispy_forms.utils import render_field, flatatt, TEMPLATE_PACK, get_template_pack
+from crispy_forms.utils import (
+    TEMPLATE_PACK, flatatt, get_template_pack, render_field,
+)
 
 
 class TemplateNameMixin(object):

--- a/crispy_forms/layout_slice.py
+++ b/crispy_forms/layout_slice.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+from crispy_forms.bootstrap import Container
 from crispy_forms.compatibility import integer_types, string_types
 from crispy_forms.exceptions import DynamicError
 from crispy_forms.layout import Fieldset, MultiField
-from crispy_forms.bootstrap import Container
 
 
 class LayoutSlice(object):

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -3,10 +3,9 @@ try:
 except ImportError:
     izip = zip
 
-from django import forms
-from django import template
-from django.template import loader, Context
+from django import forms, template
 from django.conf import settings
+from django.template import Context, loader
 
 from crispy_forms.utils import TEMPLATE_PACK, get_template_pack
 

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django import template
 from django.conf import settings
 from django.forms import forms
 from django.forms.formsets import BaseFormSet
@@ -6,10 +7,9 @@ from django.template import Context
 from django.template.loader import get_template
 from django.utils.lru_cache import lru_cache
 from django.utils.safestring import mark_safe
-from django import template
 
 from crispy_forms.exceptions import CrispyError
-from crispy_forms.utils import flatatt, TEMPLATE_PACK
+from crispy_forms.utils import TEMPLATE_PACK, flatatt
 
 
 @lru_cache()

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
+from django import template
 from django.conf import settings
 from django.forms.formsets import BaseFormSet
 from django.template.loader import get_template
 from django.utils.lru_cache import lru_cache
-from django import template
 
-from crispy_forms.helper import FormHelper
 from crispy_forms.compatibility import string_types
+from crispy_forms.helper import FormHelper
+from crispy_forms.utils import TEMPLATE_PACK, get_template_pack
 
 register = template.Library()
-# We import the filters, so they are available when doing load crispy_forms_tags
-from crispy_forms.templatetags.crispy_forms_filters import *
 
-from crispy_forms.utils import TEMPLATE_PACK, get_template_pack
+# We import the filters, so they are available when doing load crispy_forms_tags
+from crispy_forms.templatetags.crispy_forms_filters import *  # isort:skip
 
 
 class ForLoopSimulator(object):

--- a/crispy_forms/templatetags/crispy_forms_utils.py
+++ b/crispy_forms/templatetags/crispy_forms_utils.py
@@ -3,6 +3,9 @@ import re
 
 from django import template
 from django.utils.encoding import force_text
+
+from crispy_forms.compatibility import text_type
+
 try:
     from django.utils.functional import keep_lazy
 except ImportError:
@@ -13,9 +16,6 @@ except ImportError:
         def decorator(func):
             return allow_lazy(func, *args)
         return decorator
-
-from crispy_forms.compatibility import text_type
-
 
 register = template.Library()
 

--- a/crispy_forms/tests/conftest.py
+++ b/crispy_forms/tests/conftest.py
@@ -1,8 +1,7 @@
 # coding: utf-8
 import pytest
 
-from crispy_forms.layout import Layout, Div, Field, Submit, Fieldset, HTML
-
+from crispy_forms.layout import HTML, Div, Field, Fieldset, Layout, Submit
 
 only_uni_form = pytest.mark.only('uni_form')
 only_bootstrap = pytest.mark.only('bootstrap', 'bootstrap3', 'bootstrap4')

--- a/crispy_forms/tests/test_dynamic_api.py
+++ b/crispy_forms/tests/test_dynamic_api.py
@@ -1,17 +1,16 @@
 # -*- coding: utf-8 -*-
-from django import forms
-
 import pytest
 
-from .conftest import only_uni_form
+from django import forms
+
+from crispy_forms.bootstrap import AppendedText
 from crispy_forms.compatibility import string_types
 from crispy_forms.exceptions import DynamicError
 from crispy_forms.helper import FormHelper, FormHelpersException
-from crispy_forms.layout import (
-    Layout, Fieldset, MultiField, HTML, Div, Field
-)
-from crispy_forms.bootstrap import AppendedText
+from crispy_forms.layout import HTML, Div, Field, Fieldset, Layout, MultiField
 from crispy_forms.tests.forms import SampleForm
+
+from .conftest import only_uni_form
 
 
 def test_wrap_all_fields():

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -3,35 +3,39 @@ from __future__ import unicode_literals
 
 import re
 
+import pytest
+
 import django
 from django import forms
 from django.core.urlresolvers import reverse
 from django.forms.models import formset_factory
-try:
-    from django.middleware.csrf import _get_new_csrf_key
-except ImportError:
-    from django.middleware.csrf import _get_new_csrf_string as _get_new_csrf_key
-from django.template import (
-    Template, TemplateSyntaxError, Context
-)
+from django.template import Context, Template, TemplateSyntaxError
 from django.test.html import parse_html
 from django.utils.translation import ugettext_lazy as _
 
-import pytest
-
-from .conftest import only_uni_form, only_bootstrap3, only_bootstrap4, only_bootstrap
-from .forms import SampleForm, SampleFormWithMedia
 from crispy_forms.bootstrap import (
-    FieldWithButtons, PrependedAppendedText, AppendedText, PrependedText,
-    StrictButton
+    AppendedText, FieldWithButtons, PrependedAppendedText, PrependedText,
+    StrictButton,
 )
 from crispy_forms.compatibility import text_type
 from crispy_forms.helper import FormHelper, FormHelpersException
 from crispy_forms.layout import (
-    Layout, Submit, Reset, Hidden, Button, MultiField, Field
+    Button, Field, Hidden, Layout, MultiField, Reset, Submit,
 )
-from crispy_forms.utils import render_crispy_form
 from crispy_forms.templatetags.crispy_forms_tags import CrispyFormNode
+from crispy_forms.utils import render_crispy_form
+
+from .conftest import (
+    only_bootstrap, only_bootstrap3, only_bootstrap4, only_uni_form,
+)
+from .forms import SampleForm, SampleFormWithMedia
+
+try:
+    from django.middleware.csrf import _get_new_csrf_key
+except ImportError:
+    from django.middleware.csrf import _get_new_csrf_string as _get_new_csrf_key
+
+
 
 
 def test_inputs(settings):

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -1,36 +1,36 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import pytest
+
 from django import forms
 from django.core.urlresolvers import reverse
 from django.forms.models import formset_factory, modelformset_factory
-try:
-    from django.middleware.csrf import _get_new_csrf_key
-except ImportError:
-    from django.middleware.csrf import _get_new_csrf_string as _get_new_csrf_key
 from django.shortcuts import render_to_response
-from django.template import (
-    Context, RequestContext, Template
-)
-import pytest
-
-from django.test import RequestFactory
+from django.template import Context, Template
 from django.utils.translation import ugettext_lazy as _
 
-from .conftest import only_uni_form, only_bootstrap3, only_bootstrap4, only_bootstrap
-from .forms import (
-    SampleForm, SampleForm2, SampleForm3, CheckboxesSampleForm,
-    SampleForm4, CrispyTestModel, SampleForm5
-)
 from crispy_forms.bootstrap import InlineCheckboxes
 from crispy_forms.compatibility import PY2
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import (
-    Layout, Fieldset, MultiField, Row, Column, HTML, ButtonHolder,
-    Div, Submit
+    HTML, ButtonHolder, Column, Div, Fieldset, Layout, MultiField, Row, Submit,
 )
 from crispy_forms.utils import render_crispy_form
+
+from .conftest import (
+    only_bootstrap, only_bootstrap3, only_bootstrap4, only_uni_form,
+)
+from .forms import (
+    CheckboxesSampleForm, CrispyTestModel, SampleForm, SampleForm2,
+    SampleForm3, SampleForm4, SampleForm5,
+)
 from .utils import contains_partial
+
+try:
+    from django.middleware.csrf import _get_new_csrf_key
+except ImportError:
+    from django.middleware.csrf import _get_new_csrf_string as _get_new_csrf_key
 
 
 def test_invalid_unicode_characters(settings):

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -4,23 +4,20 @@ from __future__ import unicode_literals
 from django import forms
 from django.template import Context, Template
 from django.test.html import parse_html
-from django.utils.translation import ugettext as _
-from django.utils.translation import activate, deactivate
+from django.utils.translation import activate, deactivate, ugettext as _
+
+from crispy_forms.bootstrap import (
+    Accordion, AccordionGroup, Alert, AppendedText, FieldWithButtons,
+    InlineCheckboxes, InlineRadios, PrependedAppendedText, PrependedText,
+    StrictButton, Tab, TabHolder,
+)
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import HTML, Field, Layout, MultiWidgetField
+from crispy_forms.tests.utils import contains_partial
+from crispy_forms.utils import render_crispy_form
 
 from .conftest import only_bootstrap
 from .forms import CheckboxesSampleForm, SampleForm
-from crispy_forms.bootstrap import (
-    PrependedAppendedText, AppendedText, PrependedText, InlineRadios,
-    Tab, TabHolder, AccordionGroup, Accordion, Alert, InlineCheckboxes,
-    FieldWithButtons, StrictButton
-)
-from crispy_forms.helper import FormHelper
-from crispy_forms.layout import (
-    Layout, HTML, Field, MultiWidgetField
-)
-from crispy_forms.tests.utils import contains_partial
-
-from crispy_forms.utils import render_crispy_form
 
 
 def test_field_with_custom_template():

--- a/crispy_forms/tests/test_settings.py
+++ b/crispy_forms/tests/test_settings.py
@@ -1,6 +1,5 @@
 import os
 
-
 BASE_DIR = os.path.dirname(__file__)
 
 INSTALLED_APPS = (

--- a/crispy_forms/tests/test_tags.py
+++ b/crispy_forms/tests/test_tags.py
@@ -1,16 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import pytest
+
 from django.forms.forms import BoundField
 from django.forms.models import formset_factory
 from django.template import Context, Template
 
-import pytest
+from crispy_forms.exceptions import CrispyError
+from crispy_forms.templatetags.crispy_forms_field import crispy_addon
 
 from .conftest import only_bootstrap
 from .forms import SampleForm
-from crispy_forms.templatetags.crispy_forms_field import crispy_addon
-from crispy_forms.exceptions import CrispyError
 
 
 def test_as_crispy_errors_form_without_non_field_errors():

--- a/crispy_forms/tests/test_utils.py
+++ b/crispy_forms/tests/test_utils.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from crispy_forms.utils import list_difference, list_intersection, render_field
-from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Layout
+
+import pytest
+
 import django
 from django import forms
 from django.template.base import Context, Template
-import pytest
+
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout
+from crispy_forms.utils import list_difference, list_intersection, render_field
+
 
 def test_list_intersection():
     assert list_intersection([1, 3], [2, 3]) == [3]

--- a/crispy_forms/tests/urls.py
+++ b/crispy_forms/tests/urls.py
@@ -1,7 +1,6 @@
 from django.conf.urls import url
 from django.views.generic import View
 
-
 urlpatterns = [
     url(r'^simple/action/$', View.as_view(), name='simpleAction'),
 ]

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 import logging
 import sys
 
@@ -10,7 +11,7 @@ from django.utils.html import conditional_escape
 from django.utils.lru_cache import lru_cache
 
 from .base import KeepContext
-from .compatibility import text_type, PY2
+from .compatibility import PY2, text_type
 
 
 def get_template_pack():

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,13 @@ license-file = LICENSE.txt
 
 [wheel]
 universal=1
+
+[isort]
+combine_as_imports=true
+default_section=THIRDPARTY
+include_trailing_comma=true
+known_django=django
+known_first_party=crispy_forms
+line_length=79
+multi_line_output=5
+sections=FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
I have sorted imports using `isort`. The rule which I used is included also.