### PR TITLE
Update crispy_tag_forms.rst

### DIFF
--- a/docs/crispy_tag_forms.rst
+++ b/docs/crispy_tag_forms.rst
@@ -249,9 +249,9 @@ Our server side code could be::
 
 I'm using a jsonview decorator from `django-jsonview`_.
 
-Note that in Django versions 1.8 and onwards, using ``RequestContext`` in this way will not work. Instead you can provide ``render_crispy_form`` with the necessary CSRF token with the following code
+Note that in Django versions 1.8 and onwards, using ``RequestContext`` in this way will not work. Instead you can provide ``render_crispy_form`` with the necessary CSRF token with the following code::
 
-    from django.core.context_processors import csrf
+    from django.template.context_processors import csrf
     ctx = {}
     ctx.update(csrf(request))
     form_html = render_crispy_form(form, context=ctx)


### PR DESCRIPTION

![screen shot 2017-04-19 at 4 13 52 pm](https://cloud.githubusercontent.com/assets/2835946/25202502/35c82a36-251b-11e7-9986-b8a32b587486.png)

Fixed issue where code snippet was formatted incorrectly and the import path for csrf was incorrect (for Django 1.8 and upwards)