### PR TITLE
Use help-inline if inline is selected

### DIFF
--- a/crispy_forms/templates/bootstrap3/layout/field_errors.html
+++ b/crispy_forms/templates/bootstrap3/layout/field_errors.html
@@ -1,5 +1,5 @@
 {% if form_show_errors and field.errors %}
     {% for error in field.errors %}
-        <span id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="help-block"><strong>{{ error }}</strong></span>
+        <span id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="help-inline"><strong>{{ error }}</strong></span>
     {% endfor %}
 {% endif %}

--- a/crispy_forms/templates/bootstrap3/layout/help_text.html
+++ b/crispy_forms/templates/bootstrap3/layout/help_text.html
@@ -1,6 +1,6 @@
 {% if field.help_text %}
     {% if help_text_inline %}
-        <span id="hint_{{ field.auto_id }}" class="help-block">{{ field.help_text|safe }}</span>
+        <span id="hint_{{ field.auto_id }}" class="help-inline">{{ field.help_text|safe }}</span>
     {% else %}
         <p id="hint_{{ field.auto_id }}" class="help-block">{{ field.help_text|safe }}</p>
     {% endif %}


### PR DESCRIPTION
Correctly use the values of error_text_inline and help_text_inline.
Current implementation forces help-block on both instances.