### PR TITLE
Allow extra_css for more flexibility

### DIFF
--- a/crispy_forms/templates/bootstrap3/layout/tab.html
+++ b/crispy_forms/templates/bootstrap3/layout/tab.html
@@ -1,4 +1,4 @@
-<ul{% if tabs.css_id %} id="{{ tabs.css_id }}"{% endif %} class="nav nav-tabs">
+<ul{% if tabs.css_id %} id="{{ tabs.css_id }}"{% endif %} class="nav {{tabs.extra_css|default_if_none:'nav-tabs'}}">
     {{ links|safe }}
 </ul>
 <div class="tab-content panel-body">


### PR DESCRIPTION
Allowing to pass extra_css to Tab we can get more visual options like: nav-pills, nav-stacked, nav-justified and for other customizations already existing in internet like vertical tabs.