### PR TITLE
Removed support for Python 3.2 and Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,12 @@ sudo: false
 
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
 env:
   - DJANGO='django>=1.8.0,<1.9.0'
-  - DJANGO='django>=1.9.0,<1.10.0'
   - DJANGO='django>=1.10.0,<1.11.0'
   - DJANGO='django>=1.11.0,<2.0'
   - DJANGO='https://github.com/django/django/archive/master.tar.gz'
@@ -28,22 +26,12 @@ matrix:
   exclude:
     - python: "2.7"
       env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
-    - python: "3.2"
-      env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
-    - python: "3.2"
-      env: DJANGO='django>=1.11.0,<2.0'
-    - python: "3.2"
-      env: DJANGO='django>=1.10.0,<1.11.0'
-    - python: "3.2"
-      env: DJANGO='django>=1.9.0,<1.10.0'
     - python: "3.3"
       env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
     - python: "3.3"
       env: DJANGO='django>=1.11.0,<2.0'
     - python: "3.3"
       env: DJANGO='django>=1.10.0,<1.11.0'
-    - python: "3.3"
-      env: DJANGO='django>=1.9.0,<1.10.0'
     - python: "3.4"
       env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
   allow_failures:

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ django-crispy-forms
 
 The best way to have Django_ DRY forms. Build programmatic reusable layouts out of components, having full control of the rendered HTML without writing HTML in templates. All this without breaking the standard way of doing things in Django, so it plays nice with any other form application.
 
-`django-crispy-forms` supports Python 2.7/Python 3.2+ and Django 1.8+
+`django-crispy-forms` supports Python 2.7/Python 3.3+ and Django 1.8/Django 1.10+
 
 The application mainly provides:
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
 envlist =
     {py27,py33,py34,py35}-django18,
-    {py27,py34,py35}-django{19,110,111},
+    {py27,py34,py35}-django{110,111},
     {py35,py36}-django{111,latest}
 
 [testenv]
 deps =
     django18: django>=1.8.0,<1.9.0
-    django19: django>=1.9.0,<1.10.0
     django110: django>=1.10.0,<1.11.0
     django111: django>=1.11.0,<2.0
     django-latest: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
Both are passed their end-of-life date; see
- https://www.python.org/dev/peps/pep-0392/
- https://www.djangoproject.com/weblog/2017/apr/04/security-releases/