### PR TITLE
Update Bootstrap 4 accordion and accordion group

### DIFF
--- a/crispy_forms/templates/bootstrap4/accordion-group.html
+++ b/crispy_forms/templates/bootstrap4/accordion-group.html
@@ -8,7 +8,7 @@
         </h5>
     </div>
 
-    <div id="{{ div.css_id }}" class="collapse {% if div.active %} show{% endif %}" role="tabpanel"
+    <div id="{{ div.css_id }}" class="collapse{% if div.active %} show{% endif %}" role="tabpanel"
          aria-labelledby="{{ div.css_id }}" data-parent="#accordion">
         <div class="card-body">
             {{ fields|safe }}

--- a/crispy_forms/templates/bootstrap4/accordion-group.html
+++ b/crispy_forms/templates/bootstrap4/accordion-group.html
@@ -1,11 +1,16 @@
-<div class="panel panel-default">
-    <div class="panel-heading">
-        <h4 class="panel-title">
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#{{ div.data_parent }}" href="#{{ div.css_id }}">{{ div.name }}</a>
-        </h4>
+<div class="card mb-2">
+    <div class="card-header" role="tab">
+        <h5 class="mb-0">
+            <a data-toggle="collapse" href="#{{ div.css_id }}" aria-expanded="true"
+               aria-controls="{{ div.css_id }}">
+                {{ div.name }}
+            </a>
+        </h5>
     </div>
-    <div id="{{ div.css_id }}" class="panel-collapse collapse{% if div.active %} in{% endif %}" >
-        <div class="panel-body">
+
+    <div id="{{ div.css_id }}" class="collapse {% if div.active %} show{% endif %}" role="tabpanel"
+         aria-labelledby="{{ div.css_id }}" data-parent="#accordion">
+        <div class="card-body">
             {{ fields|safe }}
         </div>
     </div>

--- a/crispy_forms/templates/bootstrap4/accordion.html
+++ b/crispy_forms/templates/bootstrap4/accordion.html
@@ -1,3 +1,3 @@
-<div class="panel-group" id="{{ accordion.css_id }}">
+<div id="accordion" role="tablist">
     {{ content|safe }}
 </div>

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -249,10 +249,14 @@ class TestBootstrapLayoutObjects(object):
             assert html.count('<div class="accordion"') == 1
             assert html.count('<div class="accordion-group">') == 2
             assert html.count('<div class="accordion-heading">') == 2
-        else:
+        elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
             assert html.count('<div class="panel panel-default"') == 2
             assert html.count('<div class="panel-group"') == 1
             assert html.count('<div class="panel-heading">') == 2
+        elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap4':
+            assert html.count('<div id="accordion"') == 1
+            assert html.count('<div class="card mb-2"') == 2
+            assert html.count('<div class="card-header"') == 2
 
         assert html.count('<div id="one"') == 1
         assert html.count('<div id="two"') == 1
@@ -277,11 +281,13 @@ class TestBootstrapLayoutObjects(object):
         html = render_crispy_form(test_form)
 
         if settings.CRISPY_TEMPLATE_PACK == 'bootstrap':
-            accordion_class = "accordion-body"
-        else:
-            accordion_class = "panel-collapse"
+            accordion_class = "accordion-body collapse in"
+        elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
+            accordion_class = "panel-collapse collapse in"
+        elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap4':
+            accordion_class = "collapse show"
 
-        assert html.count('<div id="one" class="%s collapse in"' % accordion_class) == 1
+        assert html.count('<div id="one" class="%s"' % accordion_class) == 1
 
         test_form.helper.layout = Layout(
             Accordion(


### PR DESCRIPTION
This fixes `Bootstrap 4` HTML for accordion and accordion group in `django-crispy-forms`