### PR TITLE
We have a tox env twice

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     {py27,py33,py34,py35}-django18,
     {py27,py34,py35}-django{110,111},
-    {py35,py36}-django{111,latest}
+    py35-django-latest,
+    py36-django{111,-latest}
 
 [testenv]
 deps =


### PR DESCRIPTION
Not sure if it actually runs the tests for it twice, but:

```tox -l | sort -n | uniq -c
   1 py27-django110
   1 py27-django111
   1 py27-django18
   1 py33-django18
   1 py34-django110
   1 py34-django111
   1 py34-django18
   1 py35-django110
   2 py35-django111
   1 py35-django18
   1 py35-djangolatest
   1 py36-django111
   1 py36-djangolatest```