### PR TITLE
Bootstrap 4 does not use hidden any more

### DIFF
--- a/crispy_forms/templates/bootstrap4/table_inline_formset.html
+++ b/crispy_forms/templates/bootstrap4/table_inline_formset.html
@@ -31,7 +31,7 @@
         </thead>
 
         <tbody>
-            <tr class="hidden empty-form">
+            <tr class="d-none empty-form">
                 {% for field in formset.empty_form %}
                     {% include 'bootstrap4/field.html' with tag="td" form_show_labels=False %}
                 {% endfor %}


### PR DESCRIPTION
Bootstrap 3 used a class="hidden" attribute to hide content:
https://getbootstrap.com/docs/3.3/css/#helper-classes-show-hide

Bootstrap 4 uses class="d-none":
https://getbootstrap.com/docs/4.0/utilities/display/#hiding-elements

I've updated the bootstrap 4 templates to reflect this.