### PR TITLE
Fix FieldWithButtons layout

### DIFF
--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -10,7 +10,7 @@
     <div class="{{ field_class }}">
         <div class="input-group">
             {% crispy_field field %}
-            <span class="input-group-btn{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ buttons|safe }}</span>
+            <span class="input-group-append{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ buttons|safe }}</span>
         </div>
         {% include 'bootstrap4/layout/help_text_and_errors.html' %}
     </div>

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -439,8 +439,10 @@ class TestBootstrapLayoutObjects(object):
 
         if settings.CRISPY_TEMPLATE_PACK == 'bootstrap':
             assert html.count('class="input-append"') == 1
-        elif settings.CRISPY_TEMPLATE_PACK in ['bootstrap3', 'bootstrap4']:
+        elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap3':
             assert html.count('class="input-group-btn') == 1
+        elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap4':
+            assert html.count('class="input-group-append') == 1
 
     def test_hidden_fields(self):
         form = SampleForm()


### PR DESCRIPTION
Fix the class used in the `FieldWithButtons` layout
Bootstrap 4 now uses `input-group-append`