### PR TITLE
Fixed incompatiblity issue with Django 2.0.

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -128,7 +128,7 @@ class CrispyFieldNode(template.Node):
                 css_class += ' form-control'
                 if field.errors:
                     css_class += ' form-control-danger'
-            
+
             if (
                 template_pack == 'bootstrap4'
                 and not is_checkbox(field)
@@ -154,7 +154,7 @@ class CrispyFieldNode(template.Node):
                 else:
                     widget.attrs[attribute_name] = template.Variable(attribute).resolve(context)
 
-        return field
+        return str(field)
 
 
 @register.tag(name="crispy_field")


### PR DESCRIPTION
When using `{% crispy_field field %}` tag in Django 2.0, I get a `TypeError` exception: `str expected, got BoundField instance`. I traced the error to `CrispyFieldNode`  - the `render` method returns `BoundField` instance whereas it should return rendered string. I guess that previous Django versions just coerced everything `render` returns into `str` so this problem remained undetected.