### PR TITLE
Fix InlineRadios Bootstrap 4 Layout

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -124,7 +124,7 @@ class InlineRadios(Field):
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
         return super(InlineRadios, self).render(
             form, form_style, context, template_pack=template_pack,
-            extra_context={'inline_class': 'inline'}
+            extra_context={'is_inline': True}
         )
 
 

--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -124,7 +124,7 @@ class InlineRadios(Field):
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
         return super(InlineRadios, self).render(
             form, form_style, context, template_pack=template_pack,
-            extra_context={'is_inline': True}
+            extra_context={'inline_class': 'inline'}
         )
 
 

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
@@ -1,16 +1,14 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<div class="{% if inline_class %}form-check{% endif %}{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
-    {% include 'bootstrap4/layout/field_errors_block.html' %}
-
+<div class="{% if field_class %} {{ field_class }}{% endif %}" {% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
     {% for choice in field.field.choices %}
-        {% if not inline_class %}<div class="form-check">{% endif %}
-        <label id="id_{{ field.id_for_label }}_{{ forloop.counter }}" class="form-check-{% if inline_class %}{{ inline_class }}{% else %}label{% endif %}" for="id_{{ field.html_name }}_{{ forloop.counter }}">
-            <input type="checkbox" class="form-check-input"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
-            {{ choice.1|unlocalize }}
-        </label>
-      {% if not inline_class %}</div>{% endif %}
+        <div class="form-check{% if inline_class %} form-check-inline{% endif %}">
+            <input type="checkbox" class="form-check-input" {% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
+            <label id="id_{{ field.id_for_label }}_{{ forloop.counter }}" class="form-check-label" for="id_{{ field.html_name }}_{{ forloop.counter }}">
+                {{ choice.1|unlocalize }}
+            </label>
+        </div>
     {% endfor %}
 
     {% include 'bootstrap4/layout/help_text.html' %}

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
@@ -3,12 +3,12 @@
 
 <div class="{% if field_class %} {{ field_class }}{% endif %}" {% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
     {% for choice in field.field.choices %}
-        <div class="form-check{% if inline_class %} form-check-inline{% endif %}">
-            <input type="checkbox" class="form-check-input" {% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
-            <label id="id_{{ field.id_for_label }}_{{ forloop.counter }}" class="form-check-label" for="id_{{ field.html_name }}_{{ forloop.counter }}">
-                {{ choice.1|unlocalize }}
-            </label>
-        </div>
+      <div class="form-check{% if inline_class %} form-check-inline{% endif %}">
+        <input type="checkbox" class="form-check-input" {% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
+        <label for="id_{{ field.id_for_label }}_{{ forloop.counter }}" class="form-check-label">
+            {{ choice.1|unlocalize }}
+        </label>
+      </div>
     {% endfor %}
 
     {% include 'bootstrap4/layout/help_text.html' %}

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
@@ -1,7 +1,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
             <label for="{{ field.auto_id }}"  class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -2,8 +2,6 @@
 {% load l10n %}
 
 <div class="{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
-    {% include 'bootstrap4/layout/field_errors_block.html' %}
-
     {% for choice in field.field.choices %}
       <div class="form-check{% if is_inline %} form-check-inline{% endif %}">
         <input type="radio" class="form-check-input"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.id_for_label }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -5,7 +5,7 @@
     {% include 'bootstrap4/layout/field_errors_block.html' %}
 
     {% for choice in field.field.choices %}
-      <div class="form-check{% if inline_class %} form-check-inline{% endif %}">
+      <div class="form-check{% if is_inline %} form-check-inline{% endif %}">
         <input type="radio" class="form-check-input"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.id_for_label }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
         <label for="id_{{ field.id_for_label }}_{{ forloop.counter }}" class="form-check-label">
             {{ choice.1|unlocalize }}

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -1,16 +1,16 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<div class="{% if inline_class %}form-check{% endif %}{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+<div class="{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
     {% include 'bootstrap4/layout/field_errors_block.html' %}
 
     {% for choice in field.field.choices %}
-      {% if not inline_class %}<div class="form-check">{% endif %}
-        <label for="id_{{ field.id_for_label }}_{{ forloop.counter }}" class="form-check-{% if inline_class %}{{ inline_class }}{% else %}label{% endif %}">
-            <input type="radio" class="form-check-input"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.id_for_label }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
+      <div class="form-check{% if inline_class %} form-check-inline{% endif %}">
+        <input type="radio" class="form-check-input"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.id_for_label }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
+        <label for="id_{{ field.id_for_label }}_{{ forloop.counter }}" class="form-check-label">
             {{ choice.1|unlocalize }}
         </label>
-      {% if not inline_class %}</div>{% endif %}
+      </div>
     {% endfor %}
 
     {% include 'bootstrap4/layout/help_text.html' %}

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -4,7 +4,7 @@
 <div class="{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
     {% for choice in field.field.choices %}
       <div class="form-check{% if is_inline %} form-check-inline{% endif %}">
-        <input type="radio" class="form-check-input"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.id_for_label }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
+        <input type="radio" class="form-check-input"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %}{% if field.field.required %} required{% endif %} name="{{ field.html_name }}" id="id_{{ field.id_for_label }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
         <label for="id_{{ field.id_for_label }}_{{ forloop.counter }}" class="form-check-label">
             {{ choice.1|unlocalize }}
         </label>

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -3,7 +3,7 @@
 
 <div class="{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
     {% for choice in field.field.choices %}
-      <div class="form-check{% if is_inline %} form-check-inline{% endif %}">
+      <div class="form-check{% if inline_class %} form-check-inline{% endif %}">
         <input type="radio" class="form-check-input"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %}{% if field.field.required %} required{% endif %} name="{{ field.html_name }}" id="id_{{ field.id_for_label }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
         <label for="id_{{ field.id_for_label }}_{{ forloop.counter }}" class="form-check-label">
             {{ choice.1|unlocalize }}

--- a/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
@@ -4,7 +4,7 @@
     <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
-            <label for="{{ field.auto_id }}"  class="{{ label_class }}{% if not is_inline %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
+            <label for="{{ field.auto_id }}"  class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
@@ -4,7 +4,7 @@
     <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
-            <label for="{{ field.auto_id }}"  class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
+            <label for="{{ field.auto_id }}"  class="{{ label_class }}{% if not is_inline %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
@@ -1,7 +1,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
             <label for="{{ field.auto_id }}"  class="{{ label_class }}{% if not is_inline %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">


### PR DESCRIPTION
Related to Issue #793 

## Summary
* InlineRadios wasn't making correct use of `.form-check` and `.form-check-inline` as per the [Bootstrap Docs](https://getbootstrap.com/docs/4.0/components/forms/#inline)
* Changed `inline_class` to `is_inline` to better distinguish the differences
* Removed error partial as radios don't really have an invalid state (as seen [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#Providing_a_bigger_hit_area_for_your_radio_buttons)). Even bootstrap doesn't cover this case.
* Added `required` attribute to radios where applicable (which is normally the default case)

For screenshots and additional info, see #793 