### PR TITLE
Fixed incompatiblity issue with Django 2.0.

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -128,7 +128,7 @@ class CrispyFieldNode(template.Node):
                 css_class += ' form-control'
                 if field.errors:
                     css_class += ' form-control-danger'
-            
+
             if (
                 template_pack == 'bootstrap4'
                 and not is_checkbox(field)
@@ -154,7 +154,7 @@ class CrispyFieldNode(template.Node):
                 else:
                     widget.attrs[attribute_name] = template.Variable(attribute).resolve(context)
 
-        return field
+        return str(field)
 
 
 @register.tag(name="crispy_field")

--- a/crispy_forms/tests/test_tags.py
+++ b/crispy_forms/tests/test_tags.py
@@ -14,6 +14,17 @@ from .conftest import only_bootstrap
 from .forms import SampleForm
 
 
+def test_crispy_field():
+    template = Template("""
+        {% load crispy_forms_field %}
+        {% for field in form %}
+            {% crispy_field field %}
+        {% endfor %}
+    """)
+    html = template.render(Context({'form': SampleForm()}))
+    assert html.count('<input') == 8
+
+
 def test_as_crispy_errors_form_without_non_field_errors():
     template = Template("""
         {% load crispy_forms_tags %}


### PR DESCRIPTION
@carltongibson I've recreated pull request, this time with a regression test. The bug is triggered when `{% crispy_field %}` is inside another Django block tag, so existing test wasn't triggering it.