### PR TITLE
Custom file input field for Bootstrap 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: develop test
 
 develop:
-	python -m pip install -q -r requirements.txt
-	python -m pip install -q -e .
+	pip install -q -r requirements.txt
+	pip install -q -e .
 
 test: develop
 	DJANGO_SETTINGS_MODULE=crispy_forms.tests.test_settings py.test crispy_forms/tests --cov=crispy_forms

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: develop test
 
 develop:
-	pip install -q -r requirements.txt
-	pip install -q -e .
+	python -m pip install -q -r requirements.txt
+	python -m pip install -q -e .
 
 test: develop
 	DJANGO_SETTINGS_MODULE=crispy_forms.tests.test_settings py.test crispy_forms/tests --cov=crispy_forms

--- a/crispy_forms/templates/bootstrap4/field.html
+++ b/crispy_forms/templates/bootstrap4/field.html
@@ -31,6 +31,8 @@
                     {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
                 </label>
                 {% include 'bootstrap4/layout/help_text_and_errors.html' %}
+            {% elif field|is_file %}
+                {% include 'bootstrap4/layout/field_file.html' %}
             {% else %}
                 <div class="{{ field_class }}">
                     {% crispy_field field %}

--- a/crispy_forms/templates/bootstrap4/layout/field_file.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_file.html
@@ -1,6 +1,6 @@
 {% load crispy_forms_field %}
 
-<div class="custom-file">
+<div class="custom-file {{ field_class }}">
     {% crispy_field field 'class' 'custom-file-input' %}
     <label class="custom-file-label" for="{{ field.id_for_label }}">Choose file</label>
 </div>

--- a/crispy_forms/templates/bootstrap4/layout/field_file.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_file.html
@@ -1,10 +1,6 @@
 {% load crispy_forms_field %}
 
 <div class="custom-file">
-    {% if field.errors %}
-        {% crispy_field field 'class' 'custom-file-input form-control is-invalid' %}
-    {% else %}
-        {% crispy_field field 'class' 'custom-file-input form-control' %}
-    {% endif %}
+    {% crispy_field field 'class' 'custom-file-input' %}
     <label class="custom-file-label" for="{{ field.id_for_label }}">Choose file</label>
 </div>

--- a/crispy_forms/templates/bootstrap4/layout/field_file.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_file.html
@@ -1,0 +1,10 @@
+{% load crispy_forms_field %}
+
+<div class="custom-file">
+    {% if field.errors %}
+        {% crispy_field field 'class' 'custom-file-input form-control is-invalid' %}
+    {% else %}
+        {% crispy_field field 'class' 'custom-file-input form-control' %}
+    {% endif %}
+    <label class="custom-file-label" for="{{ field.id_for_label }}">Choose file</label>
+</div>

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -128,11 +128,10 @@ class CrispyFieldNode(template.Node):
                 css_class += ' form-control'
                 if field.errors:
                     css_class += ' form-control-danger'
-            
+
             if (
                 template_pack == 'bootstrap4'
                 and not is_checkbox(field)
-                and not is_file(field)
                 and not is_multivalue(field)
             ):
                 css_class += ' form-control'


### PR DESCRIPTION
### Why merge this PR?
The Issue #734 suggested to add custom file input for Bootstrap 4.

### Description
A new layout template called `file_input.html` was created which holds the HTML of the Bootstrap4 [custom file input](https://getbootstrap.com/docs/4.0/components/input-group/#custom-file-input)
A distinction was included in `field.html` which checks if the field to render is a file input field using `is_file`.
The classes `form-control` and `is-invalid` are added to the field input in order to show form errors for the field.