### PR TITLE
Ignore pytest.RemovedInPytest4Warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,5 +14,9 @@ line_length=79
 multi_line_output=5
 sections=FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
 
+[pytest]
+filterwarnings =
+    ignore::pytest.RemovedInPytest4Warning
+
 [coverage:run]
 branch = True


### PR DESCRIPTION
See http://doc.pytest.org/en/latest/changelog.html

From pytest 4.0. Will stop working for pytest 4.1