### PR TITLE
fix for foundation-6 theme

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -372,7 +372,7 @@ class Row(Div):
     """
 
     def __init__(self, *args, **kwargs):
-        self.css_class = 'formRow' if get_template_pack() == 'uni_form' else 'row'
+        self.css_class = 'formRow' if get_template_pack() == 'uni_form' else 'grid-x grid-margin-x'#'row'
         super(Row, self).__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
Layout without this edit are always rendered as vertical list of fields ignoring defined style.