### PR TITLE
Fix non-HTTPS resources

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -1,20 +1,9 @@
 <h3 style="font-size: 30px;"><a href="{{ pathto(master_doc) }}">crispy-forms</a></h3>
 <p>
-  <iframe src="http://ghbtns.com/github-btn.html?user=maraujop&repo=django-crispy-forms&type=watch&count=true&size=large"
+  <iframe src="https://ghbtns.com/github-btn.html?user=maraujop&repo=django-crispy-forms&type=watch&count=true&size=large"
     allowtransparency="true" frameborder="0" scrolling="0" width="200px" height="35px"></iframe>
 </p>
 
 <p>
   django-crispy-forms is a Django application that lets you easily build, customize and reuse forms using your favorite CSS framework, without writing template code and without having to take care of annoying details. You are currently looking at the documentation of the development release.
-</p>
-
-
-<h3>Support</h3>
-<p>
-    If you love django-crispy-forms, consider making a small donation <a href="http://flattr.com/thing/512037/django-crispy-forms">on Flattr</a>:
-</p>
-<p>
-    <a class="FlattrButton" style="display:none;" rev="flattr;button:compact;" href="https://django-crispy-forms.readthedocs.io"></a>
-    <noscript><a href="http://flattr.com/thing/512037/django-crispy-forms" target="_blank">
-    <img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Click to flattr django-crispy-forms" border="0" /></a></noscript>
 </p>

--- a/docs/_themes/kr/layout.html
+++ b/docs/_themes/kr/layout.html
@@ -9,17 +9,6 @@
 {% endblock %}
 {%- block relbar2 %}{% endblock %}
 {%- block footer %}
-    <script type="text/javascript">
-    /* <![CDATA[ */
-        (function() {
-            var s = document.createElement('script'), t = document.getElementsByTagName('script')[0];
-            s.type = 'text/javascript';
-            s.async = true;
-            s.src = 'http://api.flattr.com/js/0.6/load.js?mode=auto';
-            t.parentNode.insertBefore(s, t);
-        })();
-    /* ]]> */</script>
-
     <div class="footer">
       &copy; Copyright {{ copyright }}.
       Created using <a href="http://sphinx.pocoo.org/">Sphinx</a>.

--- a/docs/_themes/kr_small/layout.html
+++ b/docs/_themes/kr_small/layout.html
@@ -15,7 +15,7 @@
 {% block relbar2 %}
   {% if theme_github_fork %}
     <a href="http://github.com/{{ theme_github_fork }}"><img style="position: fixed; top: 0; right: 0; border: 0;"
-    src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+    src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
   {% endif %}
 {% endblock %}
 {% block sidebar1 %}{% endblock %}


### PR DESCRIPTION
Closes https://github.com/django-crispy-forms/django-crispy-forms/issues/850

I might be missing some.

The two in the reported issue are fixed.