### PR TITLE
Add ability to generate other tags than "div" to the "Div" layout class.

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -337,7 +337,8 @@ class MultiField(LayoutObject):
 
 class Div(LayoutObject):
     """
-    Layout object. It wraps fields in a <div>
+    Layout object. It wraps fields in a <div>, or alternatively any other tag you
+    specify with tag='h1'.
 
     You can set `css_id` for a DOM id and `css_class` for a DOM class. Example::
 
@@ -353,6 +354,7 @@ class Div(LayoutObject):
         if not hasattr(self, 'css_class'):
             self.css_class = kwargs.pop('css_class', None)
 
+        self.tag = kwargs.pop('tag', 'div')
         self.css_id = kwargs.pop('css_id', '')
         self.template = kwargs.pop('template', self.template)
         self.flat_attrs = flatatt(kwargs)

--- a/crispy_forms/templates/bootstrap/layout/div.html
+++ b/crispy_forms/templates/bootstrap/layout/div.html
@@ -1,4 +1,4 @@
-<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
+<{{div.tag}} {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
     {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
         {{ fields|safe }}
-</div>
+</{{div.tag}}>

--- a/crispy_forms/templates/bootstrap3/layout/div.html
+++ b/crispy_forms/templates/bootstrap3/layout/div.html
@@ -1,4 +1,4 @@
-<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
+<{{div.tag}} {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
     {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
         {{ fields|safe }}
-</div>
+</{{div.tag}}>

--- a/crispy_forms/templates/bootstrap4/layout/div.html
+++ b/crispy_forms/templates/bootstrap4/layout/div.html
@@ -1,4 +1,4 @@
-<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
+<{{div.tag}} {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
     {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
         {{ fields|safe }}
-</div>
+</{{div.tag}}>

--- a/crispy_forms/templates/uni_form/layout/div.html
+++ b/crispy_forms/templates/uni_form/layout/div.html
@@ -1,4 +1,4 @@
-<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
+<{{div.tag}} {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
     {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
         {{ fields|safe }}
-</div>
+</{{div.tag}}>

--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -108,9 +108,11 @@ Universal layout objects
 
 These ones live in module ``crispy_forms.layout``. These are layout objects that are not specific to a template pack. We'll go one by one, showing usage examples:
 
-- **Div**: It wraps fields in a ``<div>``::
+- **Div**: It wraps fields in a ``<div>`` or any other tag::
 
     Div('form_field_1', 'form_field_2', 'form_field_3', ...)
+
+If you need a different tag than ``div`` you can specify it with the ``tag`` parameter, e.g., ``Div(HTML('title'), Div(tag='h1'))``.
 
 **NOTE** Mainly in all layout objects you can set kwargs that will be used as HTML attributes. As ``class`` is a reserved keyword in Python, for it you will have to use ``css_class``. For example::
 


### PR DESCRIPTION
The layout classes are a very versatile way of formatting forms. The ``Div`` layout class can be used to group elements and give them specific layouts (through the css_class parameter). Sometimes, however, it is helpful to have other elements, too, e.g. titles (``h1`` ... ``h6``). 

This pull requests adds a parameter tag to the ``Div`` class allowing the user to set the specific html tag required. If omitted it obviously falls back to the div tag.

This allows to keep HTML tags out of the ``HTML`` class making forms easier to internationalize

    Div(HTML(_('My great form')), tag='h1')

The required adaptations are minimal and I have done them for all template sets.