### PR TITLE
Making the error message visible for input-group-prepend in BS4

### DIFF
--- a/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
@@ -24,9 +24,15 @@
                     <span class="input-group-text">{{ crispy_appended_text|safe }}</span>
                   </div>
                 {% endif %}
+                {% if error_text_inline %}
+                    {% include 'bootstrap4/layout/field_errors.html' %}
+                {% else %}
+                    {% include 'bootstrap4/layout/field_errors_block.html' %}
+                {% endif %}
             </div>
-
-            {% include 'bootstrap4/layout/help_text_and_errors.html' %}
+        {% if not help_text_inline %}
+            {% include 'bootstrap4/layout/help_text.html' %}
+        {% endif %}
         </div>
 
     </div>


### PR DESCRIPTION
The error message have to be in the input-group while the help text have to be outside, splitting the content of help_text_and_errors to do so.
### before
![Capture d’écran de 2019-09-18 16-02-41](https://user-images.githubusercontent.com/11556772/65155704-0a706680-da2e-11e9-925b-e567b83dcbb1.png)
### after
![Capture d’écran de 2019-09-18 16-02-50](https://user-images.githubusercontent.com/11556772/65155722-10664780-da2e-11e9-87c5-c2fe946cb77d.png)

Note that the left part being not rounded is a bug from BS4 itself as we can see in https://getbootstrap.com/docs/4.0/components/forms/#server-side
