### PR TITLE
Fix ID on labels

### DIFF
--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
@@ -6,7 +6,7 @@
     {% for choice in field.field.choices %}
     <div class="{%if use_custom_control%}custom-control custom-checkbox{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">
         <input type="checkbox" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{%if is_bound %} is-{% if field.errors %}in{%endif%}valid{% endif %}"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
-        <label id="id_{{ field.id_for_label }}_{{ forloop.counter }}" class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}" for="id_{{ field.html_name }}_{{ forloop.counter }}">
+        <label class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}" for="id_{{ field.html_name }}_{{ forloop.counter }}">
             {{ choice.1|unlocalize }}
         </label>
         {% if field.errors and forloop.last and not inline_class %}

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
@@ -4,7 +4,7 @@
     <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
-            <label for="{{ field.auto_id }}"  class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
+            <label for="{{ field.id_for_label }}"  class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -5,8 +5,8 @@
 
     {% for choice in field.field.choices %}
       <div class="{%if use_custom_control%}custom-control custom-radio{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">
-        <input type="radio" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{%if is_bound %} is-{% if field.errors %}in{%endif%}valid{% endif %}"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.id_for_label }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
-        <label for="id_{{ field.id_for_label }}_{{ forloop.counter }}" class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}">
+        <input type="radio" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{%if is_bound %} is-{% if field.errors %}in{%endif%}valid{% endif %}"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
+        <label for="id_{{ field.html_name }}_{{ forloop.counter }}" class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}">
             {{ choice.1|unlocalize }}
         </label>
         {% if field.errors and forloop.last and not inline_class %}
@@ -24,4 +24,3 @@
 
     {% include 'bootstrap4/layout/help_text.html' %}
 </div>
-

--- a/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
@@ -4,7 +4,7 @@
     <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
-            <label for="{{ field.auto_id }}"  class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
+            <label for="{{ field.id_for_label }}"  class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
                 {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}


### PR DESCRIPTION
This PR fixes IDs for checkbox labels. 

Some discussion on this at #816. I think what I spotted was a different issue to the end of that discussion. 816 was referring to `id_id`. The code I spotted that was wrong was outputting `id__#` (double underscore), my fix now outputs `id_name_#`

**Old:**
![Capture9](https://user-images.githubusercontent.com/39445562/65283792-dd0be180-db2f-11e9-957d-6409ae362981.PNG)

**New:**
![Capture10](https://user-images.githubusercontent.com/39445562/65283793-dd0be180-db2f-11e9-93b7-e804ce91775a.PNG)

@carltongibson do you think it's worth adding a test to check for the format of ids? (not sure how hard this will be, but am willing to give it a go!

EDIT: 

Oops - forgot about the tests so it looks like there is already something in place. Will try and look at tomorrow. 