### PR TITLE
rename test to improve coverage

### DIFF
--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -677,7 +677,7 @@ def test_error_text_inline(settings):
 
 
 @only_bootstrap3
-def test_error_and_help_inline():
+def test_error_and_help_inline_bootstrap3():
     form = SampleForm({'email': 'invalidemail'})
     form.helper = FormHelper()
     form.helper.error_text_inline = False


### PR DESCRIPTION
The test noted below was not running, I'm assuming this is due to
there being another test in the test_form_helper.py file with the same name.
Therefore I updated test name to allow test to run

Test not currently running:
@only_bootstrap3
def test_error_and_help_inline