### PR TITLE
bootstrap3 help_text.html: div instead of p

### DIFF
--- a/crispy_forms/templates/bootstrap3/layout/help_text.html
+++ b/crispy_forms/templates/bootstrap3/layout/help_text.html
@@ -2,6 +2,6 @@
     {% if help_text_inline %}
         <span id="hint_{{ field.auto_id }}" class="help-block">{{ field.help_text|safe }}</span>
     {% else %}
-        <p id="hint_{{ field.auto_id }}" class="help-block">{{ field.help_text|safe }}</p>
+        <div id="hint_{{ field.auto_id }}" class="help-block">{{ field.help_text|safe }}</div>
     {% endif %}
 {% endif %}


### PR DESCRIPTION
In current Django versions, the `help_text` of a password reset form contains a `<ul>` with password validation rules. These cannot be rendered within a `<p>`, so render it using a `<div>`.