### PR TITLE
Adjusted Row CSS class depending on template pack.

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -372,7 +372,16 @@ class Row(Div):
     """
 
     def __init__(self, *args, **kwargs):
-        self.css_class = 'formRow' if get_template_pack() == 'uni_form' else 'row'
+        # Map template packs to the css class they need here.
+        # TODO: This is a _Smell_. There should be a factory which creates a
+        #       template pack specific subclass. (Or such...)
+        row_class_map = {
+            'uni_form': 'formRow',
+            'bootstrap4': 'form-row',
+            'bootstrap3': 'row',
+        }
+        # Fetch the class, with a suitable default.
+        self.css_class = row_class_map.get(get_template_pack(), 'row')
         super(Row, self).__init__(*args, **kwargs)
 
 

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -207,6 +207,8 @@ def test_layout_fieldset_row_html_with_unicode_fieldnames(settings):
 
     if settings.CRISPY_TEMPLATE_PACK == 'uni_form':
         assert 'class="formRow rows"' in html
+    elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap4':
+        assert 'class="form-row rows"' in html
     else:
         assert 'class="row rows"' in html
     assert 'Hello!' in html


### PR DESCRIPTION
Hello @carltongibson , I have replaced the  row with form-row in class Row. This is for the issue #857 . 
The form-row is the variation of bootstrap's standard grid row that overrides the default column gutters for tighter and more compact layouts .