### PR TITLE
Explicitly test against Django v3.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
        {py35,py36}-django20,
        {py35,py36,py37,py38}-django21,
        {py35,py36,py37,py38}-django22,
+       {py36,py37,py38}-django30,
        {py36,py37,py38}-django-latest,
 
 [testenv]
@@ -12,6 +13,7 @@ deps =
     django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
     django22: django>=2.2,<2.3
+    django30: django>=3.0a1,<3.1
     django-latest: https://github.com/django/django/archive/master.tar.gz
     -rrequirements.txt
 whitelist_externals = make


### PR DESCRIPTION
Current tests are being run against v2 and latest. Tests against latest are ignored and so failing tests are easy to miss.
Updated tox.ini to explicitly test against v.3 of Django and to make tests for v.3 fail loudly.

p.s. Tests against latest are failing with an import error. They were previously passing.