### PR TITLE
Documentation | Links update & layout change

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -1,7 +1,6 @@
 <h3 style="font-size: 30px;"><a href="{{ pathto(master_doc) }}">crispy-forms</a></h3>
 <p>
-  <iframe src="https://ghbtns.com/github-btn.html?user=maraujop&repo=django-crispy-forms&type=watch&count=true&size=large"
-    allowtransparency="true" frameborder="0" scrolling="0" width="200px" height="35px"></iframe>
+  <iframe src="https://ghbtns.com/github-btn.html?user=django-crispy-forms&repo=django-crispy-forms&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe>
 </p>
 
 <p>

--- a/docs/form_helper.rst
+++ b/docs/form_helper.rst
@@ -74,9 +74,6 @@ Helper attributes you can set
 **disable_csrf = False**
     Disable CSRF token, when done, crispy-forms won't use ``{% csrf_token %}`` tag. This is useful when rendering several forms using ``{% crispy %}`` tag and ``form_tag = False`` csrf_token gets rendered several times.
 
-**use_custom_control = True**
-    It indicate whether the radio and checkbox button should use the optional UI customization of the template pack or not. Useful when you already have customization based on the default interpretation of the template pack. When enabled crispy-forms will render elements such as checkbox and radio with optional additional UI customization, when available. Defaults to ``True``.
-
 **form_error_title**
     If you are rendering a form using ``{% crispy %}`` tag and it has ``non_field_errors`` to display, they are rendered in a div. You can set the title of the div with this attribute. Example: “Form Errors”.
 
@@ -130,6 +127,16 @@ All previous, ``bootstrap`` (version 2) attributes are also settable in bootstra
 
 **field_class = ''**
     Default set to ``''``. This class will be applied to every div ``controls`` wrapping a field. This is useful for doing horizontal forms. Set it for example like this ``field_class = col-lg-8``.
+
+
+Bootstrap 4 Helper attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All previous, ``bootstrap`` (version 2 and 3) attributes are also settable in bootstrap 4 template pack ``FormHelpers``. Here are listed the ones, that are only available in ``bootstrap4`` template pack:
+
+**use_custom_control = True**
+    It indicates whether the radio and checkbox button should use the optional UI customization of the template pack or not. Useful when you already have customization based on the default interpretation of the template pack. When enabled crispy-forms will render elements such as checkbox and radio with optional additional UI customization, when available. Defaults to ``True``.
+
 
 Custom Helper attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,8 +33,8 @@ Get the most out of django-crispy-forms
 * See who's contributed to the project at `crispy-forms contributors`_
 * You can find a detailed history of the project in `Github's CHANGELOG`_
 
-.. _`crispy-forms contributors`: https://github.com/maraujop/django-crispy-forms/blob/dev/CONTRIBUTORS.txt
-.. _`Github's CHANGELOG`: https://github.com/maraujop/django-crispy-forms/blob/dev/CHANGELOG.md
+.. _`crispy-forms contributors`: https://github.com/django-crispy-forms/django-crispy-forms/blob/master/CONTRIBUTORS.txt
+.. _`Github's CHANGELOG`: https://github.com/django-crispy-forms/django-crispy-forms/blob/master/CHANGELOG.md
 
 API documentation
 ~~~~~~~~~~~~~~~~~
@@ -58,5 +58,5 @@ Think this is awesome and want to make it better? Read our contribution page, ma
 
     contributing
 
-.. _contributors: https://github.com/maraujop/django-crispy-forms/blob/dev/CONTRIBUTORS.txt
+.. _contributors: https://github.com/django-crispy-forms/django-crispy-forms/blob/master/CONTRIBUTORS.txt
 .. _Django: http://djangoproject.com

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,13 +13,13 @@ Install latest stable version into your python path using pip or easy_install::
 
 If you want to install development version (unstable), you can do so doing::
 
-    pip install git+git://github.com/maraujop/django-crispy-forms.git@dev#egg=django-crispy-forms
+    pip install git+git://github.com/django-crispy-forms/django-crispy-forms.git@dev#egg=django-crispy-forms
 
 Or, if you'd like to install the development version as a git repository (so
 you can ``git pull`` updates, use the ``-e`` flag with ``pip install``, like
 so:: 
 
-    pip install -e git+git://github.com/maraujop/django-crispy-forms.git@dev#egg=django-crispy-forms
+    pip install -e git+git://github.com/django-crispy-forms/django-crispy-forms.git@dev#egg=django-crispy-forms
 
 Add ``crispy_forms`` to your ``INSTALLED_APPS`` in settings.py::
 
@@ -30,7 +30,7 @@ Add ``crispy_forms`` to your ``INSTALLED_APPS`` in settings.py::
 
 In production environments, always activate Django template cache loader. This is available since Django 1.2 and what it does is basically load templates once, then cache the result for every subsequent render. This leads to a significant performance improvement. See how to set it up using fabulous `Django docs page`_.
 
-.. _`Django docs page`: https://docs.djangoproject.com/en/1.10/ref/templates/api/#django.template.loaders.cached.Loader
+.. _`Django docs page`: https://docs.djangoproject.com/en/2.2/ref/templates/api/#django.template.loaders.cached.Loader
 
 Template packs
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
1. Changed links in documentation to point at current django-crispy-form repo (sidebar & index files)
2. Moved new BS4 control (use_custom_control) to a new BS4 helper section (form_helper)

