### PR TITLE
Remove Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG for django-crispy-forms
 
+## Next release
+* Removed support for Python 2
+
 ## 1.8.1 (2019-11-22)
 
 * Fixing FileField UI bug introduced with 1.8.0

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -108,3 +108,4 @@ Contributors
 * Dmitry Dygalo <Stranger6667>
 * Lee Skillen <lskillen>
 * Bryan Brancotte <bryan-brancotte>
+* David Smith <smithdc1>

--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -1,12 +1,9 @@
-from __future__ import unicode_literals
-
 from random import randint
 
 from django.template import Template
 from django.template.defaultfilters import slugify
 from django.template.loader import render_to_string
 
-from .compatibility import text_type
 from .layout import Div, Field, LayoutObject, TemplateNameMixin
 from .utils import TEMPLATE_PACK, flatatt, render_field
 
@@ -186,7 +183,7 @@ class StrictButton(TemplateNameMixin):
         self.flat_attrs = flatatt(kwargs)
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
-        self.content = Template(text_type(self.content)).render(context)
+        self.content = Template(str(self.content)).render(context)
         template = self.get_template_name(template_pack)
         context.update({'button': self})
 
@@ -331,7 +328,7 @@ class Accordion(ContainerHolder):
         # accordion group needs the parent div id to set `data-parent` (I don't
         # know why). This needs to be a unique id
         if not self.css_id:
-            self.css_id = "-".join(["accordion", text_type(randint(1000, 9999))])
+            self.css_id = "-".join(["accordion", str(randint(1000, 9999))])
 
         # Open the group that should be open.
         self.open_target_group_for_form(form)

--- a/crispy_forms/compatibility.py
+++ b/crispy_forms/compatibility.py
@@ -1,23 +1,6 @@
 import sys
 import django
 
-try:
-    basestring
-except:
-    basestring = str  # Python3
-
-PY2 = sys.version_info[0] == 2
-if not PY2:
-    text_type = str
-    binary_type = bytes
-    string_types = (str,)
-    integer_types = (int,)
-else:
-    text_type = unicode
-    binary_type = str
-    string_types = basestring
-    integer_types = (int, long)
-
 if django.VERSION < (3, 0):
     from django.utils.lru_cache import lru_cache
 else:

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -3,7 +3,6 @@ import re
 
 from django.utils.safestring import mark_safe
 
-from crispy_forms.compatibility import string_types
 from crispy_forms.exceptions import FormHelpersException
 from crispy_forms.layout import Layout
 from crispy_forms.layout_slice import LayoutSlice
@@ -82,7 +81,7 @@ class DynamicLayoutHandler(object):
         and not a copy.
         """
         # when key is a string containing the field name
-        if isinstance(key, string_types):
+        if isinstance(key, str):
             # Django templates access FormHelper attributes using dictionary [] operator
             # This could be a helper['form_id'] access, not looking for a field
             if hasattr(self, key):

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -1,10 +1,7 @@
-from __future__ import unicode_literals
-
 from django.template import Template
 from django.template.loader import render_to_string
 from django.utils.html import conditional_escape
 
-from crispy_forms.compatibility import string_types, text_type
 from crispy_forms.utils import (
     TEMPLATE_PACK, flatatt, get_template_pack, render_field,
 )
@@ -55,7 +52,7 @@ class LayoutObject(TemplateNameMixin):
                 [[0,3], 'field_name2']
             ]
         """
-        return self.get_layout_objects(string_types, index=None, greedy=True)
+        return self.get_layout_objects(str, index=None, greedy=True)
 
     def get_layout_objects(self, *LayoutClasses, **kwargs):
         """
@@ -85,7 +82,7 @@ class LayoutObject(TemplateNameMixin):
 
         for i, layout_object in enumerate(self.fields):
             if isinstance(layout_object, LayoutClasses):
-                if len(LayoutClasses) == 1 and LayoutClasses[0] == string_types:
+                if len(LayoutClasses) == 1 and LayoutClasses[0] == str:
                     pointers.append([index + [i], layout_object])
                 else:
                     pointers.append([index + [i], layout_object.__class__.__name__.lower()])
@@ -194,7 +191,7 @@ class BaseInput(TemplateNameMixin):
         Renders an `<input />` if container is used as a Layout object.
         Input button value can be a variable in context.
         """
-        self.value = Template(text_type(self.value)).render(context)
+        self.value = Template(str(self.value)).render(context)
         template = self.get_template_name(template_pack)
         context.update({'input': self})
 
@@ -288,7 +285,7 @@ class Fieldset(LayoutObject):
 
         legend = ''
         if self.legend:
-            legend = '%s' % Template(text_type(self.legend)).render(context)
+            legend = '%s' % Template(str(self.legend)).render(context)
 
         template = self.get_template_name(template_pack)
         return render_to_string(
@@ -402,7 +399,7 @@ class HTML(object):
         self.html = html
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
-        return Template(text_type(self.html)).render(context)
+        return Template(str(self.html)).render(context)
 
 
 class Field(LayoutObject):

--- a/crispy_forms/layout_slice.py
+++ b/crispy_forms/layout_slice.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from crispy_forms.bootstrap import Container
-from crispy_forms.compatibility import integer_types, string_types
 from crispy_forms.exceptions import DynamicError
 from crispy_forms.layout import Fieldset, MultiField
 
@@ -11,7 +10,7 @@ class LayoutSlice(object):
 
     def __init__(self, layout, key):
         self.layout = layout
-        if isinstance(key, integer_types):
+        if isinstance(key, int):
             self.slice = slice(key, key + 1, 1)
         else:
             self.slice = key
@@ -137,7 +136,7 @@ class LayoutSlice(object):
                 # If update_attrs is applied to a string, we call to its wrapping layout object
                 if (
                     function.__name__ == 'update_attrs'
-                    and isinstance(layout_object, string_types)
+                    and isinstance(layout_object, str)
                 ):
                     function(previous_layout_object)
                 else:

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -1,8 +1,3 @@
-try:
-    from itertools import izip
-except ImportError:
-    izip = zip
-
 from django import forms, template
 from django.conf import settings
 from django.template import Context, loader
@@ -71,7 +66,7 @@ def css_class(field):
 def pairwise(iterable):
     """s -> (s0,s1), (s2,s3), (s4, s5), ..."""
     a = iter(iterable)
-    return izip(a, a)
+    return zip(a, a)
 
 
 class CrispyFieldNode(template.Node):

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 from django import template
+from django.conf import settings
+from django.forms.formsets import BaseFormSet
+from django.template.loader import get_template
+
+from crispy_forms.compatibility import lru_cache, string_types
 from crispy_forms.helper import FormHelper
-from crispy_forms.utils import get_template_pack
+from crispy_forms.utils import TEMPLATE_PACK, get_template_pack
 
 register = template.Library()
 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.forms.formsets import BaseFormSet
 from django.template.loader import get_template
 
-from crispy_forms.compatibility import lru_cache, string_types
+from crispy_forms.compatibility import lru_cache
 from crispy_forms.helper import FormHelper
 from crispy_forms.utils import TEMPLATE_PACK, get_template_pack
 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -1,12 +1,7 @@
 # -*- coding: utf-8 -*-
 from django import template
-from django.conf import settings
-from django.forms.formsets import BaseFormSet
-from django.template.loader import get_template
-
-from crispy_forms.compatibility import lru_cache, string_types
 from crispy_forms.helper import FormHelper
-from crispy_forms.utils import TEMPLATE_PACK, get_template_pack
+from crispy_forms.utils import get_template_pack
 
 register = template.Library()
 
@@ -253,7 +248,7 @@ def do_uni_form(parser, token):
     # {% crispy form 'bootstrap' %}
     if (
         helper is not None and
-        isinstance(helper, string_types) and
+        isinstance(helper, str) and
         ("'" in helper or '"' in helper)
     ):
         template_pack = helper

--- a/crispy_forms/templatetags/crispy_forms_utils.py
+++ b/crispy_forms/templatetags/crispy_forms_utils.py
@@ -4,7 +4,6 @@ import re
 from django import template
 from django.utils.encoding import force_text
 
-from crispy_forms.compatibility import text_type
 
 try:
     from django.utils.functional import keep_lazy
@@ -20,7 +19,7 @@ except ImportError:
 register = template.Library()
 
 
-@keep_lazy(text_type)
+@keep_lazy(str)
 def remove_spaces(value):
     html = re.sub(r'>\s{3,}<', '> <', force_text(value))
     return re.sub(r'/><', r'/> <', force_text(html))

--- a/crispy_forms/tests/test_dynamic_api.py
+++ b/crispy_forms/tests/test_dynamic_api.py
@@ -4,7 +4,6 @@ import pytest
 from django import forms
 
 from crispy_forms.bootstrap import AppendedText
-from crispy_forms.compatibility import string_types
 from crispy_forms.exceptions import DynamicError
 from crispy_forms.helper import FormHelper, FormHelpersException
 from crispy_forms.layout import HTML, Div, Field, Fieldset, Layout, MultiField
@@ -173,12 +172,12 @@ def test_update_attributes_and_wrap_once():
     )
     helper.layout = layout
 
-    helper.filter(string_types, greedy=True).wrap_once(Field)
+    helper.filter(str, greedy=True).wrap_once(Field)
     helper.filter(Field, greedy=True).update_attributes(readonly=True)
 
     assert isinstance(layout[0], Field)
     assert isinstance(layout[1][0], Field)
-    assert isinstance(layout[1][0][0], string_types)
+    assert isinstance(layout[1][0][0], str)
     assert isinstance(layout[2], Field)
     assert layout[1][0].attrs == {'readonly': True}
     assert layout[0].attrs == {'readonly': True}
@@ -218,7 +217,7 @@ def test_get_layout_objects():
         Div('password1'),
         'password2',
     )
-    assert layout_3.get_layout_objects(string_types, max_level=2) == [
+    assert layout_3.get_layout_objects(str, max_level=2) == [
         [[0], 'email'],
         [[1, 0], 'password1'],
         [[2], 'password2']
@@ -252,7 +251,7 @@ def test_filter_and_wrap():
     )
     helper.layout = layout
 
-    helper.filter(string_types).wrap(Field, css_class="test-class")
+    helper.filter(str).wrap(Field, css_class="test-class")
     assert isinstance(layout.fields[0], Field)
     assert isinstance(layout.fields[1], Div)
     assert isinstance(layout.fields[2], Field)
@@ -400,8 +399,8 @@ def test_exclude_by_widget_and_wrap(advanced_layout):
     assert isinstance(form.helper.layout[1], Field)
     # Check others stay the same
     assert isinstance(form.helper.layout[0][3][1], HTML)
-    assert isinstance(form.helper.layout[0][1][0][0], string_types)
-    assert isinstance(form.helper.layout[0][4][0], string_types)
+    assert isinstance(form.helper.layout[0][1][0][0], str)
+    assert isinstance(form.helper.layout[0][4][0], str)
 
 
 def test_all_without_layout():
@@ -483,8 +482,8 @@ def test__getitem__layout_object():
     assert isinstance(layout[0][0], Div)
     assert isinstance(layout[0][0][0], Div)
     assert isinstance(layout[0][1], Div)
-    assert isinstance(layout[0][1][0], string_types)
-    assert isinstance(layout[0][2], string_types)
+    assert isinstance(layout[0][1][0], str)
+    assert isinstance(layout[0][2], str)
 
 
 def test__getattr__append_layout_object():
@@ -493,8 +492,8 @@ def test__getattr__append_layout_object():
     )
     layout.append('password1')
     assert isinstance(layout[0], Div)
-    assert isinstance(layout[0][0], string_types)
-    assert isinstance(layout[1], string_types)
+    assert isinstance(layout[0][0], str)
+    assert isinstance(layout[1], str)
 
 
 def test__setitem__layout_object():

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -16,7 +16,6 @@ from crispy_forms.bootstrap import (
     AppendedText, FieldWithButtons, PrependedAppendedText, PrependedText,
     StrictButton,
 )
-from crispy_forms.compatibility import text_type
 from crispy_forms.helper import FormHelper, FormHelpersException
 from crispy_forms.layout import (
     Button, Field, Hidden, Layout, MultiField, Reset, Submit,
@@ -139,7 +138,7 @@ def test_form_show_errors_non_field_errors():
 
     # Ensure those errors were rendered
     assert '<li>Passwords dont match</li>' in html
-    assert text_type(_('This field is required.')) in html
+    assert str(_('This field is required.')) in html
     assert 'error' in html
 
     # Now we render without errors
@@ -149,7 +148,7 @@ def test_form_show_errors_non_field_errors():
 
     # Ensure errors were not rendered
     assert '<li>Passwords dont match</li>' not in html
-    assert text_type(_('This field is required.')) not in html
+    assert str(_('This field is required.')) not in html
     assert 'error' not in html
 
 

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import pytest
 
 import django
@@ -11,7 +9,6 @@ from django.template import Context, Template
 from django.utils.translation import ugettext_lazy as _
 
 from crispy_forms.bootstrap import Field, InlineCheckboxes
-from crispy_forms.compatibility import PY2
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import (
     HTML, ButtonHolder, Column, Div, Fieldset, Layout, MultiField, Row, Submit,
@@ -67,12 +64,8 @@ def test_unicode_form_field():
         helper = FormHelper()
         helper.layout = Layout('contraseña')
 
-    if PY2:
-        with pytest.raises(Exception):
-            render_crispy_form(UnicodeForm())
-    else:
-        html = render_crispy_form(UnicodeForm())
-        assert 'id="id_contraseña"' in html
+    html = render_crispy_form(UnicodeForm())
+    assert 'id="id_contraseña"' in html
 
 
 def test_meta_extra_fields_with_missing_fields():

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 import sys
 
@@ -10,7 +8,7 @@ from django.template.loader import get_template
 from django.utils.functional import SimpleLazyObject
 
 from .base import KeepContext
-from .compatibility import PY2, text_type, lru_cache
+from .compatibility import lru_cache
 
 
 def get_template_pack():
@@ -60,20 +58,6 @@ def render_field(
             return field.render(
                 form, form_style, context, template_pack=template_pack,
             )
-        else:
-            # In Python 2 form field names cannot contain unicode characters without ASCII mapping
-            if PY2:
-                # This allows fields to be unicode strings, always they don't use non ASCII
-                try:
-                    if isinstance(field, text_type):
-                        field = field.encode('ascii').decode()
-                    # If `field` is not unicode then we turn it into a unicode string, otherwise doing
-                    # str(field) would give no error and the field would not be resolved, causing confusion
-                    else:
-                        field = text_type(field)
-
-                except (UnicodeEncodeError, UnicodeDecodeError):
-                    raise Exception("Field '%s' is using forbidden unicode characters" % field)
 
         try:
             # Injecting HTML attributes into field's widget, Django handles rendering these


### PR DESCRIPTION
This PR removes support for python 2. 

1) Update tox.ini and travis.yml to stop testing for python 2
2) removal of python 2 in compatibility.py, and put python 3 commands into individual files
3) removal of izip in crispy_forms_field
4) added to change log (I've not change the readme file, so this still refers to python 2 (v1.8 supports python 2). We will need to change this at some point.

Looking forward to the review and feedback. 