### PR TITLE
Reworking layout.Column so it uses only template + bugfix

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -387,11 +387,16 @@ class Row(Div):
 
 class Column(Div):
     """
-    Layout object. It wraps fields in a div whose default class is "formColumn". Example::
+    Layout object. It wraps fields in a div so the wrapper can be used as a column. Example::
 
         Column('form_field_1', 'form_field_2')
+
+    Depending on the template, css class associated to the div is formColumn, row, or nothing. For this last case, you
+     must provide css classes. Example::
+
+        Column('form_field_1', 'form_field_2', css_class='col-xs-6',)
     """
-    css_class = 'formColumn'
+    template = "%s/layout/column.html"
 
 
 class HTML(object):

--- a/crispy_forms/templates/bootstrap/layout/column.html
+++ b/crispy_forms/templates/bootstrap/layout/column.html
@@ -1,0 +1,3 @@
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="{{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+        {{ fields|safe }}
+</div>

--- a/crispy_forms/templates/bootstrap3/layout/column.html
+++ b/crispy_forms/templates/bootstrap3/layout/column.html
@@ -1,0 +1,3 @@
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="{{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+        {{ fields|safe }}
+</div>

--- a/crispy_forms/templates/bootstrap3/layout/column.html
+++ b/crispy_forms/templates/bootstrap3/layout/column.html
@@ -1,3 +1,3 @@
-<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="{{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="formColumn {{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
         {{ fields|safe }}
 </div>

--- a/crispy_forms/templates/bootstrap4/layout/column.html
+++ b/crispy_forms/templates/bootstrap4/layout/column.html
@@ -1,0 +1,3 @@
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="col {{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+        {{ fields|safe }}
+</div>

--- a/crispy_forms/templates/uni_form/layout/column.html
+++ b/crispy_forms/templates/uni_form/layout/column.html
@@ -1,0 +1,3 @@
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="formColumn {{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+        {{ fields|safe }}
+</div>

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -251,6 +251,43 @@ def test_change_layout_dynamically_delete_field():
     assert 'email' not in html
 
 
+def test_column_has_css_classes(settings):
+    template = Template("""
+        {% load crispy_forms_tags %}
+        {% crispy form form_helper %}
+    """)
+
+    form = SampleForm()
+    form_helper = FormHelper()
+    form_helper.add_layout(
+        Layout(
+            Fieldset(
+                'Company Data',
+                'is_company',
+                'email',
+                'password1',
+                'password2',
+                css_id="multifield_info",
+            ),
+            Column(
+                'first_name',
+                'last_name',
+            )
+        )
+    )
+
+    c = Context({'form': form, 'form_helper': form_helper})
+    html = template.render(c)
+    print(html)
+
+    if settings.CRISPY_TEMPLATE_PACK == 'uni_form':
+        assert html.count('formColumn') == 1
+        assert html.count('col') == 0
+    elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap4':
+        assert html.count('formColumn') == 0
+        assert html.count('col') == 1
+
+
 def test_formset_layout(settings):
     SampleFormSet = formset_factory(SampleForm, extra=3)
     formset = SampleFormSet()


### PR DESCRIPTION
All the css class are out of layout.py in independant html template
=> Add support of column out-of-the-box for BS4
Bugfix
=> remove the usage of css class `formColumn` in BS3 & BS4

Before
![Capture d’écran de 2019-10-22 13-53-37](https://user-images.githubusercontent.com/11556772/67283427-ee039600-f4d3-11e9-8dcf-d7700d8a297c.png)

After
![Capture d’écran de 2019-10-22 13-54-05](https://user-images.githubusercontent.com/11556772/67283426-ee039600-f4d3-11e9-80be-65c9f907ee48.png)
