### PR TITLE
Fixed #918: Removed use of BS4 custom file field.

### DIFF
--- a/crispy_forms/templates/bootstrap4/field.html
+++ b/crispy_forms/templates/bootstrap4/field.html
@@ -35,8 +35,6 @@
                     {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
                 </label>
                 {% include 'bootstrap4/layout/help_text_and_errors.html' %}
-            {% elif field|is_file %}
-                {% include 'bootstrap4/layout/field_file.html' %}
             {% else %}
                 <div class="{{ field_class }}">
                     {% crispy_field field %}

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -132,6 +132,7 @@ class CrispyFieldNode(template.Node):
             if (
                 template_pack == 'bootstrap4'
                 and not is_multivalue(field)
+                and not is_file(field)
             ):
                 if not is_checkbox(field):
                     css_class += ' form-control'


### PR DESCRIPTION
It's not functional without custom JS to go with it.

Partially reverts #809.