### PR TITLE
Add option to automatically populate field placeholders

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -216,6 +216,7 @@ class FormHelper(DynamicLayoutHandler):
     field_template = None
     disable_csrf = False
     use_custom_control = True
+    auto_populate_placeholders = False
     label_class = ''
     field_class = ''
     include_media = True
@@ -370,7 +371,7 @@ class FormHelper(DynamicLayoutHandler):
             'field_class': self.field_class,
             'include_media': self.include_media
         }
-        
+
         if template_pack == 'bootstrap4':
             bootstrap_size_match = re.findall(r'col-(xl|lg|md|sm)-(\d+)', self.label_class)
             if bootstrap_size_match:

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -95,6 +95,14 @@ class CrispyFieldNode(template.Node):
         # If template pack has been overridden in FormHelper we can pick it from context
         template_pack = context.get('template_pack', TEMPLATE_PACK)
 
+        if context.get('auto_populate_placeholders'):
+            try:
+                if field.field.widget.input_type == 'text':
+                    field.initial = field.field.label
+            except AttributeError:
+                pass
+
+
         # There are special django widgets that wrap actual widgets,
         # such as forms.widgets.MultiWidget, admin.widgets.RelatedFieldWidgetWrapper
         widgets = getattr(field.field.widget, 'widgets', [getattr(field.field.widget, 'widget', field.field.widget)])

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -162,6 +162,7 @@ class BasicNode(template.Node):
             'help_text_inline': attrs.get("help_text_inline", False),
             'html5_required': attrs.get("html5_required", False),
             'form_show_labels': attrs.get("form_show_labels", True),
+            'auto_populate_placeholders': attrs.get("auto_populate_placeholders", False),
             'disable_csrf': attrs.get("disable_csrf", False),
             'inputs': attrs.get('inputs', []),
             'is_formset': is_formset,

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -522,6 +522,18 @@ def test_helper_std_field_template_no_layout():
         assert html.count('id="div_id_%s"' % field) == 1
 
 
+def test_auto_populate_placeholders():
+    form = SampleForm()
+    form.helper = FormHelper()
+    html = render_crispy_form(form)
+    # default = False
+    assert html.count('value') == 0
+    form.helper.auto_populate_placeholders = True
+    html = render_crispy_form(form)
+    # 3 text fields in sample form
+    assert html.count('value') == 3
+
+
 @only_uni_form
 def test_form_show_errors():
     form = SampleForm({


### PR DESCRIPTION
This is my attempt to fix #786 

Now... Whilst I've learnt a fair amount looking at this and it's been very enjoyable I'm not entirely sure it should be merged. 

I understand that we should show restraint when adding new features, and as described in the issue there is a DRY way of doing this outside of crispy-forms. I guess at least this one *shouldn't* break anything. 

Appreciate your thoughts, both on the topic of implementing this issue, and some feedback on my code would be nice as well (whatever the outcome).

Below is an image of the placeholder matching the label. 
![Capture](https://user-images.githubusercontent.com/39445562/68077520-4c2a5600-fdbd-11e9-837b-7c6b75d6931f.PNG)
.

