### PR TITLE
Using counter0 instead of revcounter0 to check if item is last in ForLoopSimulator

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -49,7 +49,7 @@ class ForLoopSimulator(object):
         self.revcounter -= 1
         self.revcounter0 -= 1
         self.first = False
-        self.last = (self.revcounter0 == self.len_values - 1)
+        self.last = (self.counter0 == self.len_values - 1)
 
 
 class BasicNode(template.Node):


### PR DESCRIPTION
Hi there,
While using the formset utilities I ran into a strange behavior: When you try to use `forloop.last` to apply specific tags like show in the [docs](https://django-crispy-forms.readthedocs.io/en/latest/crispy_tag_formsets.html), the `forloop.last` was never `True` if there were more than a single form.

Digging a bit in the code, I found out the `ForLoopSimulator`, and I believe that in the `ForLoopSimulator::iter(...)`, the way `self.last` is updated is wrong.
I submitted a fix by just changing the variable used, although there are a ton of different ways to check if the current item is the last item :sweat_smile:   