### PR TITLE
Add Django as dependency, needed to run tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ wheel
 pytest
 pytest-cov
 pytest-django
+django


### PR DESCRIPTION
When cloning the repository from scratch, the tests won't run if `Django` is not installed, thus `make test` fails.