### PR TITLE
Cleanup CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
-sudo: false
-
-
-dist: xenial
 language: python
 python:
   - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
-  - "3.8-dev"
+  - "3.8"
 
 cache: pip
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
-       {py27,py35,py36}-django111,
-       {py35,py36}-django20,
-       {py35,py36,py37,py38}-django21,
-       {py35,py36,py37,py38}-django22,
-       {py36,py37,py38}-django30,
-       {py36,py37,py38}-django-latest,
+    {py27,py35,py36}-django111,
+    {py35,py36}-django20,
+    {py35,py36,py37}-django21,
+    {py35,py36,py37}-django22,
+    {py36,py37,py38}-django30,
+    {py36,py37,py38}-django-latest,
 
 [testenv]
 deps =
@@ -21,4 +21,4 @@ commands = make test
 ignore_outcome =
     django-latest: True
 setenv =
-       PYTHONDONTWRITEBYTECODE=1
+    PYTHONDONTWRITEBYTECODE=1

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     {py27,py35,py36}-django111,
     {py35,py36}-django20,
     {py35,py36,py37}-django21,
-    {py35,py36,py37}-django22,
+    {py35,py36,py37,py38}-django22,
     {py36,py37,py38}-django30,
     {py36,py37,py38}-django-latest,
 
@@ -13,7 +13,7 @@ deps =
     django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
     django22: django>=2.2,<2.3
-    django30: django>=3.0a1,<3.1
+    django30: django>=3.0rc1,<3.1
     django-latest: https://github.com/django/django/archive/master.tar.gz
     -rrequirements.txt
 whitelist_externals = make


### PR DESCRIPTION
- Python 3.8 is now official
- Django 2.x is not officially compatible with Python 3.8
- Cleanup indent in tox.ini