### PR TITLE
Add GitHub actions for Flake8

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,34 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+#    - name: Install dependencies
+#      run: |
+#        python -m pip install --upgrade pip
+#        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings.
+        flake8 . --exit-zero
+#    - name: Test with pytest
+#      run: |
+#        pip install pytest
+#        pytest

--- a/crispy_forms/compatibility.py
+++ b/crispy_forms/compatibility.py
@@ -2,6 +2,6 @@ import sys
 import django
 
 if django.VERSION < (3, 0):
-    from django.utils.lru_cache import lru_cache
+    from django.utils.lru_cache import lru_cache  # noqa: F401
 else:
-    from functools import lru_cache
+    from functools import lru_cache  # noqa: F401

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -11,7 +11,7 @@ from crispy_forms.utils import TEMPLATE_PACK, get_template_pack
 register = template.Library()
 
 # We import the filters, so they are available when doing load crispy_forms_tags
-from crispy_forms.templatetags.crispy_forms_filters import *  # isort:skip
+from crispy_forms.templatetags.crispy_forms_filters import *  # NOQA: F403,F401 isort:skip
 
 
 class ForLoopSimulator(object):

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -634,7 +634,7 @@ def test_multifield_errors():
 
 
 @only_bootstrap3
-def test_bootstrap_form_show_errors():
+def test_bootstrap_form_show_errors_bs3():
     form = SampleForm({
         'email': 'invalidemail',
         'first_name': 'first_name_too_long',
@@ -662,7 +662,7 @@ def test_bootstrap_form_show_errors():
 
 
 @only_bootstrap4
-def test_bootstrap_form_show_errors():
+def test_bootstrap_form_show_errors_bs4():
     form = SampleForm({
         'email': 'invalidemail',
         'first_name': 'first_name_too_long',

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,5 +25,9 @@ branch = True
 exclude =
     # The conf file is auto generated, ignore it
     docs/conf.py
-# mirrors max-line-length of Django
+# mirrors max-line-length of Django. This is shorter than GitHub editor (127)
 max-line-length = 119
+statistics = True
+max-complexity = 10
+count = True
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,10 @@ markers =
 
 [coverage:run]
 branch = True
+
+[flake8]
+exclude =
+    # The conf file is auto generated, ignore it
+    docs/conf.py
+# mirrors max-line-length of Django
+max-line-length = 119


### PR DESCRIPTION
Here is the first small step towards exploring github actions. 

This PR enables flake8 only. To get the 'test' to pass I have had to amend a couple of test names (good spot flake8!?), and I've added some exceptions. 

I've had to take an opinion on the settings for flake8. I've copied GitHub's recommendations with the exception of line length. 

This leaves c.50 'errors' on the current code base. We will need to consider how to approach these. 