### PR TITLE
Render fields not included in the explicit layout in the order they are provided

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -8,7 +8,7 @@ from crispy_forms.exceptions import FormHelpersException
 from crispy_forms.layout import Layout
 from crispy_forms.layout_slice import LayoutSlice
 from crispy_forms.utils import (
-    TEMPLATE_PACK, flatatt, list_difference, list_intersection, render_field,
+    TEMPLATE_PACK, flatatt, list_difference, render_field,
 )
 
 try:
@@ -313,11 +313,20 @@ class FormHelper(DynamicLayoutHandler):
         if self.render_unmentioned_fields or self.render_hidden_fields or self.render_required_fields:
             fields = tuple(form.fields.keys())
             left_fields_to_render = list_difference(fields, form.rendered_fields)
+
+            # If the user has Meta.fields defined, we use that order
+            if hasattr(form, 'Meta') and hasattr(form.Meta, 'fields'):
+                field_indexes = {field: index for index, field in enumerate(form.Meta.fields)}
+                end_index = len(form.Meta.fields)
+                left_fields_to_render = sorted(left_fields_to_render, key=lambda x: field_indexes.get(x, end_index))
+
             for field in left_fields_to_render:
+                # We still respect the configuration of the helper
+                # regarding which fields to render
                 if (
                     self.render_unmentioned_fields or
-                    self.render_hidden_fields and form.fields[field].widget.is_hidden or
-                    self.render_required_fields and form.fields[field].widget.is_required
+                    (self.render_hidden_fields and form.fields[field].widget.is_hidden) or
+                    (self.render_required_fields and form.fields[field].widget.is_required)
                 ):
                     html += render_field(
                         field,
@@ -326,28 +335,6 @@ class FormHelper(DynamicLayoutHandler):
                         context,
                         template_pack=template_pack
                     )
-
-        # If the user has Meta.fields defined, not included in the layout,
-        # we suppose they need to be rendered
-        if hasattr(form, 'Meta'):
-            if hasattr(form.Meta, 'fields'):
-                current_fields = tuple(getattr(form, 'fields', {}).keys())
-                meta_fields = getattr(form.Meta, 'fields')
-
-                fields_to_render = list_intersection(current_fields, meta_fields)
-                left_fields_to_render = list_difference(fields_to_render, form.rendered_fields)
-
-                for field in left_fields_to_render:
-                    # We still respect the configuration of the helper
-                    # regarding which fields to render
-                    if (
-                        self.render_unmentioned_fields or
-                        (self.render_hidden_fields and
-                         form.fields[field].widget.is_hidden) or
-                        (self.render_required_fields and
-                         form.fields[field].widget.is_required)
-                    ):
-                        html += render_field(field, form, self.form_style, context)
 
         return mark_safe(html)
 

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -311,8 +311,8 @@ class FormHelper(DynamicLayoutHandler):
 
         # Rendering some extra fields if specified
         if self.render_unmentioned_fields or self.render_hidden_fields or self.render_required_fields:
-            fields = set(form.fields.keys())
-            left_fields_to_render = fields - form.rendered_fields
+            fields = tuple(form.fields.keys())
+            left_fields_to_render = list_difference(fields, form.rendered_fields)
             for field in left_fields_to_render:
                 if (
                     self.render_unmentioned_fields or

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -313,7 +313,6 @@ class FormHelper(DynamicLayoutHandler):
         if self.render_unmentioned_fields or self.render_hidden_fields or self.render_required_fields:
             fields = tuple(form.fields.keys())
             left_fields_to_render = list_difference(fields, form.rendered_fields)
-
             for field in left_fields_to_render:
                 if (
                     self.render_unmentioned_fields or

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -314,15 +314,7 @@ class FormHelper(DynamicLayoutHandler):
             fields = tuple(form.fields.keys())
             left_fields_to_render = list_difference(fields, form.rendered_fields)
 
-            # If the user has Meta.fields defined, we use that order
-            if hasattr(form, 'Meta') and hasattr(form.Meta, 'fields'):
-                field_indexes = {field: index for index, field in enumerate(form.Meta.fields)}
-                end_index = len(form.Meta.fields)
-                left_fields_to_render = sorted(left_fields_to_render, key=lambda x: field_indexes.get(x, end_index))
-
             for field in left_fields_to_render:
-                # We still respect the configuration of the helper
-                # regarding which fields to render
                 if (
                     self.render_unmentioned_fields or
                     (self.render_hidden_fields and form.fields[field].widget.is_hidden) or

--- a/crispy_forms/tests/forms.py
+++ b/crispy_forms/tests/forms.py
@@ -147,3 +147,19 @@ class SampleForm6(forms.ModelForm):
         model = CrispyEmptyChoiceTestModel
         fields = ['fruit']
         widgets = {'fruit': forms.RadioSelect() }
+
+
+class SampleForm7(forms.ModelForm):
+    password2 = forms.CharField(label="re-enter password", max_length=30, required=True, widget=forms.PasswordInput())
+
+    class Meta:
+        model = CrispyTestModel
+        fields = ('email', 'password', 'password2')
+
+
+class SampleForm8(forms.ModelForm):
+    password2 = forms.CharField(label="re-enter password", max_length=30, required=True, widget=forms.PasswordInput())
+
+    class Meta:
+        model = CrispyTestModel
+        fields = ('email', 'password2', 'password')

--- a/crispy_forms/tests/forms.py
+++ b/crispy_forms/tests/forms.py
@@ -150,6 +150,7 @@ class SampleForm6(forms.ModelForm):
 
 
 class SampleForm7(forms.ModelForm):
+    is_company = forms.CharField(label="company", required=False, widget=forms.CheckboxInput())
     password2 = forms.CharField(label="re-enter password", max_length=30, required=True, widget=forms.PasswordInput())
 
     class Meta:
@@ -158,6 +159,7 @@ class SampleForm7(forms.ModelForm):
 
 
 class SampleForm8(forms.ModelForm):
+    is_company = forms.CharField(label="company", required=False, widget=forms.CheckboxInput())
     password2 = forms.CharField(label="re-enter password", max_length=30, required=True, widget=forms.PasswordInput())
 
     class Meta:

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -471,8 +471,16 @@ def test_render_unmentioned_fields_order():
     test_form.helper.render_unmentioned_fields = True
 
     html = render_crispy_form(test_form)
-    assert html.count('<input') == 3
-    assert html.index('id="div_id_password"') < html.index('id="div_id_password2"')
+    assert html.count('<input') == 4
+    assert (
+        # From layout
+        html.index('id="div_id_email"')
+        # From form.Meta.fields
+        < html.index('id="div_id_password"')
+        < html.index('id="div_id_password2"')
+        # From fields
+        < html.index('id="div_id_is_company"')
+    )
 
     test_form = SampleForm8()
     test_form.helper = FormHelper()
@@ -482,8 +490,16 @@ def test_render_unmentioned_fields_order():
     test_form.helper.render_unmentioned_fields = True
 
     html = render_crispy_form(test_form)
-    assert html.count('<input') == 3
-    assert html.index('id="div_id_password2"') < html.index('id="div_id_password"')
+    assert html.count('<input') == 4
+    assert (
+        # From layout
+        html.index('id="div_id_email"')
+        # From form.Meta.fields
+        < html.index('id="div_id_password2"')
+        < html.index('id="div_id_password"')
+        # From fields
+        < html.index('id="div_id_is_company"')
+    )
 
 
 def test_render_hidden_fields():

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -444,6 +444,18 @@ def test_disable_csrf():
     assert 'csrf' not in html
 
 
+def test_render_unmentioned_fields():
+    test_form = SampleForm()
+    test_form.helper = FormHelper()
+    test_form.helper.layout = Layout(
+        'email'
+    )
+    test_form.helper.render_unmentioned_fields = True
+
+    html = render_crispy_form(test_form)
+    assert html.count('<input') == 8
+
+
 def test_render_hidden_fields():
     from .utils import contains_partial
     test_form = SampleForm()

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -27,7 +27,13 @@ from crispy_forms.utils import render_crispy_form
 from .conftest import (
     only_bootstrap, only_bootstrap3, only_bootstrap4, only_uni_form,
 )
-from .forms import SampleForm, SampleFormWithMedia, SampleFormWithMultiValueField
+from .forms import (
+    SampleForm,
+    SampleForm7,
+    SampleForm8,
+    SampleFormWithMedia,
+    SampleFormWithMultiValueField,
+)
 
 try:
     from django.middleware.csrf import _get_new_csrf_key
@@ -454,6 +460,30 @@ def test_render_unmentioned_fields():
 
     html = render_crispy_form(test_form)
     assert html.count('<input') == 8
+
+
+def test_render_unmentioned_fields_order():
+    test_form = SampleForm7()
+    test_form.helper = FormHelper()
+    test_form.helper.layout = Layout(
+        'email'
+    )
+    test_form.helper.render_unmentioned_fields = True
+
+    html = render_crispy_form(test_form)
+    assert html.count('<input') == 3
+    assert html.index('id="div_id_password"') < html.index('id="div_id_password2"')
+
+    test_form = SampleForm8()
+    test_form.helper = FormHelper()
+    test_form.helper.layout = Layout(
+        'email'
+    )
+    test_form.helper.render_unmentioned_fields = True
+
+    html = render_crispy_form(test_form)
+    assert html.count('<input') == 3
+    assert html.index('id="div_id_password2"') < html.index('id="div_id_password"')
 
 
 def test_render_hidden_fields():


### PR DESCRIPTION
Fixes #951 
Follows https://github.com/django-crispy-forms/django-crispy-forms/pull/539#issuecomment-307984618

The first loop is a superset of the second loop.
Let's combine the loops and use the order in Meta, followed by the order in form.

More info: [https://stackoverflow.com/questions/59101176/how-do-i-specify-the-order-of-fields-in-a-form-django-crispy-forms/59120457#59120457](https://stackoverflow.com/a/59120457/8601760)