### PR TITLE
Ref #926 Fix class on File upload input field.

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -135,6 +135,8 @@ class CrispyFieldNode(template.Node):
             ):
                 if not is_checkbox(field):
                     css_class += ' form-control'
+                    if is_file(field):
+                        css_class += '-file'
                 if field.errors:
                     css_class += ' is-invalid'
 


### PR DESCRIPTION
Bootstrap 4 uses the "form-control-file" class for file input fields but the "form-control" class was incorrectly being applied to file input fields leaving a field border that is not present in Bootstrap 4 Documentation.
This will append to the class to correct the class string.