### PR TITLE
Improve CSS for column layout object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 * Removed support for Python 2
+* CSS for Column layout object in Bootstrap 4 template pack changed to 'col-md'. Default is now over ridden when another 'col' class is added to css_class.
 
 ## 1.8.1 (2019-11-22)
 

--- a/crispy_forms/templates/bootstrap4/layout/column.html
+++ b/crispy_forms/templates/bootstrap4/layout/column.html
@@ -1,3 +1,6 @@
-<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="col {{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %}
+     class="{% if 'col' in div.css_class %}{{ div.css_class|default:'' }}{% else %}col-md {{ div.css_class|default:'' }}{% endif %}" {{ div.flat_attrs|safe }}>
         {{ fields|safe }}
 </div>
+
+

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -264,7 +264,7 @@ def test_column_has_css_classes(settings):
             Column(
                 'first_name',
                 'last_name',
-            )
+            ),
         )
     )
 
@@ -277,7 +277,42 @@ def test_column_has_css_classes(settings):
         assert html.count('col') == 0
     elif settings.CRISPY_TEMPLATE_PACK == 'bootstrap4':
         assert html.count('formColumn') == 0
-        assert html.count('col') == 1
+        assert html.count('col-md') == 1
+
+
+@only_bootstrap4
+def test_bs4_column_css_classes(settings):
+    template = Template("""
+        {% load crispy_forms_tags %}
+        {% crispy form form_helper %}
+    """)
+
+    form = SampleForm()
+    form_helper = FormHelper()
+    form_helper.add_layout(
+        Layout(
+            Column(
+                'first_name',
+                'last_name',
+            ),
+            Column(
+                'first_name',
+                'last_name',
+                css_class='col-sm'
+            ),
+            Column(
+                'first_name',
+                'last_name',
+                css_class='mb-4'
+            ),
+        )
+    )
+
+    c = Context({'form': form, 'form_helper': form_helper})
+    html = template.render(c)
+
+    assert html.count('col-md') == 2
+    assert html.count('col-sm') == 1
 
 
 def test_formset_layout(settings):


### PR DESCRIPTION
This PR is to fix #963 

Improved default CSS to `col-md` for bootstrap 4 so columns stack on smaller screens by default. If additional css classes are added the default is removed if it includes a `col` class. New tests are provided for this functionality. 

My main question is this explicit enough, is this too clever and gives a surprising / unexpected result? 

