### PR TITLE
Drop Django V1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 * Removed support for Python 2
+* Removed support for Django version 1
 * CSS for Column layout object in Bootstrap 4 template pack changed to 'col-md'. Default is now over ridden when another 'col' class is added to css_class.
 
 ## 1.8.1 (2019-11-22)

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -1,6 +1,7 @@
 import re
 
 from django.utils.safestring import mark_safe
+from django.urls import reverse, NoReverseMatch
 
 from crispy_forms.exceptions import FormHelpersException
 from crispy_forms.layout import Layout
@@ -8,12 +9,6 @@ from crispy_forms.layout_slice import LayoutSlice
 from crispy_forms.utils import (
     TEMPLATE_PACK, flatatt, list_difference, render_field,
 )
-
-try:
-    from django.urls import reverse, NoReverseMatch
-except ImportError:
-    # Django < 1.10
-    from django.core.urlresolvers import reverse, NoReverseMatch
 
 
 class DynamicLayoutHandler:

--- a/crispy_forms/templatetags/crispy_forms_utils.py
+++ b/crispy_forms/templatetags/crispy_forms_utils.py
@@ -2,19 +2,7 @@ import re
 
 from django import template
 from django.utils.encoding import force_str
-
-
-try:
-    from django.utils.functional import keep_lazy
-except ImportError:
-    # django < 1.10
-    from django.utils.functional import allow_lazy
-    # bare version for remove_spaces
-
-    def keep_lazy(*args):
-        def decorator(func):
-            return allow_lazy(func, *args)
-        return decorator
+from django.utils.functional import keep_lazy
 
 register = template.Library()
 

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -7,6 +7,8 @@ from django import forms
 from django.forms.models import formset_factory
 from django.template import Context, Template, TemplateSyntaxError
 from django.test.html import parse_html
+from django.urls import reverse
+from django.middleware.csrf import _get_new_csrf_string
 from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.bootstrap import (
@@ -30,17 +32,6 @@ from .forms import (
     SampleFormWithMedia,
     SampleFormWithMultiValueField,
 )
-
-try:
-    from django.middleware.csrf import _get_new_csrf_key
-except ImportError:
-    from django.middleware.csrf import _get_new_csrf_string as _get_new_csrf_key
-
-try:
-    from django.urls import reverse
-except ImportError:
-    # Django < 1.10
-    from django.core.urlresolvers import reverse
 
 
 def test_inputs(settings):
@@ -389,7 +380,7 @@ def test_formset_with_helper_without_layout(settings):
     SampleFormSet = formset_factory(SampleForm, extra=3)
     testFormSet = SampleFormSet()
 
-    c = Context({'testFormSet': testFormSet, 'formset_helper': form_helper, 'csrf_token': _get_new_csrf_key()})
+    c = Context({'testFormSet': testFormSet, 'formset_helper': form_helper, 'csrf_token': _get_new_csrf_string()})
     html = template.render(c)
 
     assert html.count('<form') == 1
@@ -418,7 +409,7 @@ def test_CSRF_token_POST_form():
     # The middleware only initializes the CSRF token when processing a real request
     # So using RequestContext or csrf(request) here does not work.
     # Instead I set the key `csrf_token` to a CSRF token manually, which `csrf_token` tag uses
-    c = Context({'form': SampleForm(), 'form_helper': form_helper, 'csrf_token': _get_new_csrf_key()})
+    c = Context({'form': SampleForm(), 'form_helper': form_helper, 'csrf_token': _get_new_csrf_string()})
     html = template.render(c)
 
     assert 'csrfmiddlewaretoken' in html
@@ -432,7 +423,7 @@ def test_CSRF_token_GET_form():
         {% crispy form form_helper %}
     """)
 
-    c = Context({'form': SampleForm(), 'form_helper': form_helper, 'csrf_token': _get_new_csrf_key()})
+    c = Context({'form': SampleForm(), 'form_helper': form_helper, 'csrf_token': _get_new_csrf_string()})
     html = template.render(c)
 
     assert 'csrfmiddlewaretoken' not in html
@@ -442,7 +433,7 @@ def test_disable_csrf():
     form = SampleForm()
     helper = FormHelper()
     helper.disable_csrf = True
-    html = render_crispy_form(form, helper, {'csrf_token': _get_new_csrf_key()})
+    html = render_crispy_form(form, helper, {'csrf_token': _get_new_csrf_string()})
     assert 'csrf' not in html
 
 

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -124,10 +124,8 @@ def test_i18n():
         HTML(_("Enter a valid value."))
     )
     html = render_crispy_form(form)
-    if DJANGO_VERSION >= (1, 11):
-        assert "Introduzca un valor válido" in html
-    else:
-        assert "Introduzca un valor correcto" in html
+    assert "Introduzca un valor válido" in html
+
     deactivate()
 
 

--- a/crispy_forms/tests/test_utils.py
+++ b/crispy_forms/tests/test_utils.py
@@ -21,8 +21,7 @@ def test_render_field_with_none_field():
     rendered = render_field(field=None, form=None, form_style=None, context=None)
     assert rendered == ''
 
-@pytest.mark.skipif(django.VERSION < (1, 9),
-                    reason="Custom BoundField behavior is was introduced in 1.9.")
+
 def test_custom_bound_field():
     from django.forms.boundfield import BoundField
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    {py27,py35,py36}-django111,
     {py35,py36}-django20,
     {py35,py36,py37}-django21,
     {py35,py36,py37,py38}-django22,
@@ -9,7 +8,6 @@ envlist =
 
 [testenv]
 deps =
-    django111: django>=1.11.0,<2.0
     django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
     django22: django>=2.2,<2.3


### PR DESCRIPTION
To remove compatibility for Django version 1.

The one bit which needed further research as it's not documented in the code is `_get_new_csrf_string`. Django docs show 'string' in [django version 2.2](https://docs.djangoproject.com/en/2.2/_modules/django/middleware/csrf/) and 'key' in [django version 1](https://docs.djangoproject.com/en/1.8/_modules/django/middleware/csrf/). I've therefore removed the option to try for 'key'. 