### PR TITLE
Only show MultiField if fields have errors

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -309,6 +309,7 @@ class MultiField(LayoutObject):
         self.template = kwargs.pop('template', self.template)
         self.field_template = kwargs.pop('field_template', self.field_template)
         self.flat_attrs = flatatt(kwargs)
+        self.has_errors = False
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
         # If a field within MultiField contains errors
@@ -316,6 +317,7 @@ class MultiField(LayoutObject):
             for field in map(lambda pointer: pointer[1], self.get_field_names()):
                 if field in form.errors:
                     self.css_class += " error"
+                    self.has_errors = True
 
         field_template = self.field_template % template_pack
         fields_output = self.get_rendered_fields(

--- a/crispy_forms/templates/bootstrap3/layout/multifield.html
+++ b/crispy_forms/templates/bootstrap3/layout/multifield.html
@@ -2,7 +2,7 @@
     {% if multifield.css_class %}class="{{ multifield.css_class }}"{% endif %}
     {{ multifield.flat_attrs|safe }}>
 
-    {% if form_show_errors %}
+    {% if form_show_errors and multifield.has_errors %}
         <div class="alert alert-danger" role="alert">
         {% for field in multifield.bound_fields %}
             {% if field.errors %}


### PR DESCRIPTION
I noticed that when using the 'bootstrap3' template pack, the MultiField layout object shows the alert box for errors regardless of whether there actually are any. Based on the 'layouts/multifield.html' template, it seems the only prerequisite for showing the alert is that "form_show_errors" is enabled.

This was just a quick patch to solve my problem without disabling form errors entirely so I'm sure it'll be worth another look-over before marking for review.