### PR TITLE
Flake8 on pull request

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -314,7 +314,7 @@ class FormHelper(DynamicLayoutHandler):
 
         return mark_safe(html)
 
-    def get_attributes(self, template_pack=TEMPLATE_PACK):
+    def get_attributes(self, template_pack=TEMPLATE_PACK):  # noqa: C901
         """
         Used by crispy_forms_tags to get helper attributes
         """

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -75,7 +75,7 @@ class CrispyFieldNode(template.Node):
         self.attrs = attrs
         self.html5_required = "html5_required"
 
-    def render(self, context):
+    def render(self, context):  # noqa: C901
         # Nodes are not threadsafe so we must store and look up our instance
         # variables in the current rendering context first
         if self not in context.render_context:
@@ -185,7 +185,7 @@ def crispy_addon(field, append="", prepend="", form_show_labels=True):
         {% crispy_addon form.my_field append=".00" %}
     """
     if field:
-        context = Context({"field": field, "form_show_errors": True, "form_show_labels": form_show_labels,})
+        context = Context({"field": field, "form_show_errors": True, "form_show_labels": form_show_labels})
         template = loader.get_template("%s/layout/prepended_appended_text.html" % get_template_pack())
         context["crispy_prepended_text"] = prepend
         context["crispy_appended_text"] = append

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -594,7 +594,7 @@ def test_form_show_errors():
 
 @only_uni_form
 def test_multifield_errors():
-    form = SampleForm({"email": "invalidemail", "password1": "yes", "password2": "yes",})
+    form = SampleForm({"email": "invalidemail", "password1": "yes", "password2": "yes"})
     form.helper = FormHelper()
     form.helper.layout = Layout(MultiField("legend", "email"))
     form.is_valid()
@@ -795,7 +795,9 @@ def test_label_class_and_field_class():
     dom = parse_html(html)
 
     snippet = parse_html(
-        '<div class="form-group"> <div class="controls col-lg-offset-2 col-lg-8"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput" id="id_is_company" name="is_company" type="checkbox" />company'
+        '<div class="form-group"> <div class="controls col-lg-offset-2 col-lg-8"> '
+        '<div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> '
+        '<input class="checkboxinput" id="id_is_company" name="is_company" type="checkbox" />company'
     )
     assert dom.count(snippet)
     assert html.count("col-lg-8") == 7
@@ -806,7 +808,9 @@ def test_label_class_and_field_class():
     dom = parse_html(html)
 
     snippet = parse_html(
-        '<div class="form-group"> <div class="controls col-sm-offset-3 col-md-offset-4 col-sm-8 col-md-6"> <div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> <input class="checkboxinput" id="id_is_company" name="is_company" type="checkbox" />company'
+        '<div class="form-group"> <div class="controls col-sm-offset-3 col-md-offset-4 col-sm-8 col-md-6"> '
+        '<div id="div_id_is_company" class="checkbox"> <label for="id_is_company" class=""> '
+        '<input class="checkboxinput" id="id_is_company" name="is_company" type="checkbox" />company'
     )
     assert dom.count(snippet)
     assert html.count("col-sm-8") == 7

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -1,6 +1,5 @@
 import pytest
 
-import django
 from django import forms
 from django.forms.models import formset_factory, modelformset_factory
 from django.middleware.csrf import _get_new_csrf_string
@@ -23,7 +22,6 @@ from .forms import (
     SampleForm2,
     SampleForm3,
     SampleForm4,
-    SampleForm5,
     SampleForm6,
 )
 from .utils import contains_partial
@@ -170,7 +168,7 @@ def test_layout_fieldset_row_html_with_unicode_fieldnames(settings):
         {% crispy form form_helper %}
     """
     )
-    c = Context({"form": SampleForm(), "form_helper": form_helper, "flag": True, "message": "Hello!",})
+    c = Context({"form": SampleForm(), "form_helper": form_helper, "flag": True, "message": "Hello!"})
     html = template.render(c)
 
     assert 'id="fieldset_company_data"' in html

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -1,4 +1,3 @@
-from django import VERSION as DJANGO_VERSION
 from django import forms
 from django.template import Context, Template
 from django.test.html import parse_html
@@ -77,7 +76,7 @@ def test_field_type_hidden():
     test_form.helper = FormHelper()
     test_form.helper.layout = Layout(Field("email", type="hidden", data_test=12), Field("datetime_field"),)
 
-    c = Context({"test_form": test_form,})
+    c = Context({"test_form": test_form})
     html = template.render(c)
 
     # Check form parameters
@@ -322,7 +321,8 @@ class TestBootstrapLayoutObjects:
         if settings.CRISPY_TEMPLATE_PACK == "bootstrap4":
             assert (
                 html.count(
-                    '<ul class="nav nav-tabs"> <li class="nav-item"><a class="nav-link active" href="#custom-name" data-toggle="tab">One</a></li>'
+                    '<ul class="nav nav-tabs"> <li class="nav-item">'
+                    '<a class="nav-link active" href="#custom-name" data-toggle="tab">One</a></li>'
                 )
                 == 1
             )
@@ -330,7 +330,8 @@ class TestBootstrapLayoutObjects:
         else:
             assert (
                 html.count(
-                    '<ul class="nav nav-tabs"> <li class="tab-pane active"><a href="#custom-name" data-toggle="tab">One</a></li>'
+                    '<ul class="nav nav-tabs"> <li class="tab-pane active">'
+                    '<a href="#custom-name" data-toggle="tab">One</a></li>'
                 )
                 == 1
             )

--- a/crispy_forms/tests/test_utils.py
+++ b/crispy_forms/tests/test_utils.py
@@ -1,6 +1,3 @@
-import pytest
-
-import django
 from django import forms
 from django.template.base import Template
 from django.template.context import Context
@@ -15,7 +12,7 @@ def test_list_intersection():
 
 
 def test_list_difference():
-    assert list_difference([3, 1, 2, 3], [4, 1,]) == [3, 2]
+    assert list_difference([3, 1, 2, 3], [4, 1]) == [3, 2]
 
 
 def test_render_field_with_none_field():

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -25,7 +25,7 @@ def default_field_template(template_pack=TEMPLATE_PACK):
     return get_template("%s/field.html" % template_pack)
 
 
-def render_field(
+def render_field(  # noqa: C901
     field,
     form,
     form_style,


### PR DESCRIPTION
We started to use github actions at the end of last year. The first step is to get flake8 working and currently it is configured to run on push so that it doesn't give errors on pull requests. 

This pull requests finalises flake8 compatibility and therefore I also propose we move to running flake8 for all pull requests. Yes we have #noqa flags in a few places but I think there is value in adding flake8 on `pull_request` now. 

I'll look to raise the current noqa flags on an issue so we can tackle those separately. Some of these (e.g. C901 below) would imply re-write of the main render function and therefore warrants deeper thought. 
