### PR TITLE
Isort

### DIFF
--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -1,0 +1,23 @@
+name: Python application
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install isort
+      run: |
+        python -m pip install --upgrade pip
+        pip install isort
+    - name: run isort
+      run: |
+        cd crispy_forms
+        isort -c

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -6,9 +6,7 @@ from django.utils.safestring import mark_safe
 from crispy_forms.exceptions import FormHelpersException
 from crispy_forms.layout import Layout
 from crispy_forms.layout_slice import LayoutSlice
-from crispy_forms.utils import (
-    TEMPLATE_PACK, flatatt, list_difference, render_field,
-)
+from crispy_forms.utils import TEMPLATE_PACK, flatatt, list_difference, render_field
 
 
 class DynamicLayoutHandler:

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -1,7 +1,7 @@
 import re
 
+from django.urls import NoReverseMatch, reverse
 from django.utils.safestring import mark_safe
-from django.urls import reverse, NoReverseMatch
 
 from crispy_forms.exceptions import FormHelpersException
 from crispy_forms.layout import Layout

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -2,9 +2,7 @@ from django.template import Template
 from django.template.loader import render_to_string
 from django.utils.html import conditional_escape
 
-from crispy_forms.utils import (
-    TEMPLATE_PACK, flatatt, get_template_pack, render_field,
-)
+from crispy_forms.utils import TEMPLATE_PACK, flatatt, get_template_pack, render_field
 
 
 class TemplateNameMixin:

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -11,24 +11,14 @@ from django.test.html import parse_html
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from crispy_forms.bootstrap import (
-    AppendedText, FieldWithButtons, PrependedAppendedText, PrependedText,
-    StrictButton,
-)
+from crispy_forms.bootstrap import AppendedText, FieldWithButtons, PrependedAppendedText, PrependedText, StrictButton
 from crispy_forms.helper import FormHelper, FormHelpersException
-from crispy_forms.layout import (
-    Button, Field, Hidden, Layout, MultiField, Reset, Submit,
-)
+from crispy_forms.layout import Button, Field, Hidden, Layout, MultiField, Reset, Submit
 from crispy_forms.templatetags.crispy_forms_tags import CrispyFormNode
 from crispy_forms.utils import render_crispy_form
 
-from .conftest import (
-    only_bootstrap, only_bootstrap3, only_bootstrap4, only_uni_form,
-)
-from .forms import (
-    SampleForm, SampleForm7, SampleForm8, SampleFormWithMedia,
-    SampleFormWithMultiValueField,
-)
+from .conftest import only_bootstrap, only_bootstrap3, only_bootstrap4, only_uni_form
+from .forms import SampleForm, SampleForm7, SampleForm8, SampleFormWithMedia, SampleFormWithMultiValueField
 
 
 def test_inputs(settings):

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -5,10 +5,10 @@ import pytest
 import django
 from django import forms
 from django.forms.models import formset_factory
+from django.middleware.csrf import _get_new_csrf_string
 from django.template import Context, Template, TemplateSyntaxError
 from django.test.html import parse_html
 from django.urls import reverse
-from django.middleware.csrf import _get_new_csrf_string
 from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.bootstrap import (
@@ -26,10 +26,7 @@ from .conftest import (
     only_bootstrap, only_bootstrap3, only_bootstrap4, only_uni_form,
 )
 from .forms import (
-    SampleForm,
-    SampleForm7,
-    SampleForm8,
-    SampleFormWithMedia,
+    SampleForm, SampleForm7, SampleForm8, SampleFormWithMedia,
     SampleFormWithMultiValueField,
 )
 

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -3,11 +3,11 @@ import pytest
 import django
 from django import forms
 from django.forms.models import formset_factory, modelformset_factory
+from django.middleware.csrf import _get_new_csrf_string
 from django.shortcuts import render
 from django.template import Context, Template
-from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
-from django.middleware.csrf import _get_new_csrf_string
+from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.bootstrap import Field, InlineCheckboxes
 from crispy_forms.helper import FormHelper
@@ -20,8 +20,9 @@ from .conftest import (
     only_bootstrap, only_bootstrap3, only_bootstrap4, only_uni_form,
 )
 from .forms import (
-    CheckboxesSampleForm, CrispyTestModel, CrispyEmptyChoiceTestModel,
-    SampleForm, SampleForm2, SampleForm3, SampleForm4, SampleForm5, SampleForm6,
+    CheckboxesSampleForm, CrispyEmptyChoiceTestModel, CrispyTestModel,
+    SampleForm, SampleForm2, SampleForm3, SampleForm4, SampleForm5,
+    SampleForm6,
 )
 from .utils import contains_partial
 

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -5,7 +5,7 @@ from django import forms
 from django.forms.models import formset_factory, modelformset_factory
 from django.shortcuts import render
 from django.template import Context, Template
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
 from django.middleware.csrf import _get_new_csrf_string
 

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -11,17 +11,19 @@ from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.bootstrap import Field, InlineCheckboxes
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import (
-    HTML, ButtonHolder, Column, Div, Fieldset, Layout, MultiField, Row, Submit,
-)
+from crispy_forms.layout import HTML, ButtonHolder, Column, Div, Fieldset, Layout, MultiField, Row, Submit
 from crispy_forms.utils import render_crispy_form
 
-from .conftest import (
-    only_bootstrap, only_bootstrap3, only_bootstrap4, only_uni_form,
-)
+from .conftest import only_bootstrap, only_bootstrap3, only_bootstrap4, only_uni_form
 from .forms import (
-    CheckboxesSampleForm, CrispyEmptyChoiceTestModel, CrispyTestModel,
-    SampleForm, SampleForm2, SampleForm3, SampleForm4, SampleForm5,
+    CheckboxesSampleForm,
+    CrispyEmptyChoiceTestModel,
+    CrispyTestModel,
+    SampleForm,
+    SampleForm2,
+    SampleForm3,
+    SampleForm4,
+    SampleForm5,
     SampleForm6,
 )
 from .utils import contains_partial

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -1,12 +1,23 @@
-from django import VERSION as DJANGO_VERSION, forms
+from django import VERSION as DJANGO_VERSION
+from django import forms
 from django.template import Context, Template
 from django.test.html import parse_html
-from django.utils.translation import activate, deactivate, gettext as _
+from django.utils.translation import activate, deactivate
+from django.utils.translation import gettext as _
 
 from crispy_forms.bootstrap import (
-    Accordion, AccordionGroup, Alert, AppendedText, FieldWithButtons,
-    InlineCheckboxes, InlineRadios, PrependedAppendedText, PrependedText,
-    StrictButton, Tab, TabHolder,
+    Accordion,
+    AccordionGroup,
+    Alert,
+    AppendedText,
+    FieldWithButtons,
+    InlineCheckboxes,
+    InlineRadios,
+    PrependedAppendedText,
+    PrependedText,
+    StrictButton,
+    Tab,
+    TabHolder,
 )
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Field, Layout, MultiWidgetField

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -1,7 +1,7 @@
 from django import forms, VERSION as DJANGO_VERSION
 from django.template import Context, Template
 from django.test.html import parse_html
-from django.utils.translation import activate, deactivate, ugettext as _
+from django.utils.translation import activate, deactivate, gettext as _
 
 from crispy_forms.bootstrap import (
     Accordion, AccordionGroup, Alert, AppendedText, FieldWithButtons,

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -1,4 +1,4 @@
-from django import forms, VERSION as DJANGO_VERSION
+from django import VERSION as DJANGO_VERSION, forms
 from django.template import Context, Template
 from django.test.html import parse_html
 from django.utils.translation import activate, deactivate, gettext as _

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,13 +5,14 @@ license-file = LICENSE.txt
 universal=1
 
 [isort]
-combine_as_imports=true
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=119
 default_section=THIRDPARTY
-include_trailing_comma=true
 known_django=django
 known_first_party=crispy_forms
-line_length=79
-multi_line_output=5
 sections=FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
 
 [tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 import os
 import sys
+
+from setuptools import find_packages, setup
+
 import crispy_forms
-
-from setuptools import setup, find_packages
-
 
 if sys.argv[-1] == 'publish':
     if os.system("pip freeze | grep wheel"):


### PR DESCRIPTION
I noticed that in setup.cfg we have isort settings. 

This pull requests runs isort on the current codebase and also introduces a github action to verify that code is formatted. 

I did come across an action that runs isort on push to master and automatically posts a commit if needed & could also do this for Black. So we don't need validate against black and isort. We just accept PRs and GH actions automatically posts a further commit if code isn't quite formatted correctly. Is this too much?