### PR TITLE
GitHub Actions C/I testing

### DIFF
--- a/.github/workflows/ci-testing-django-master.yml
+++ b/.github/workflows/ci-testing-django-master.yml
@@ -1,0 +1,28 @@
+name: C/I testing - Django master
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python}}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install https://github.com/django/django/archive/master.tar.gz
+    - name: Test with pytest
+      run: |
+        cd /home/runner/work/django-crispy-forms/django-crispy-forms/
+        make test

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -1,0 +1,41 @@
+name: C/I Testing.
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [3.5, 3.6, 3.7, 3.8]
+        django: [2.2.*, 3.0.*]
+        exclude: 
+          # exclude python 3.5 with django v3+
+          - python: 3.5
+            django: 3.0.*
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python}}
+
+
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install django==${{ matrix.django }}
+    - name: Test with pytest
+      run: |
+        cd /home/runner/work/django-crispy-forms/django-crispy-forms/
+        make test


### PR DESCRIPTION
This pull request adds C/I testing using GitHub actions. This gives the same test scenarios as currently configured on Travis CI. This is another step in transitioning to GitHub actions. 

I've added two for files, one to test against published releases of Django and another for testing against Django latest / master branch. For the published releases version I've also added caching so downloads don't have to keep taking place each time the tests are run.

Currently tests are failing against Django master as we need #947 to be merged. 

For completeness (I don't think it's a biggie for this project) one potential downsides of GitHub over Travis is testing against new versions of Python. We had tests running against 3.8dev for a long time with Travis, and GitHub took a while to add support for 3.8 even once it was released. However, GitHub actions was new and they are always innovating so 🤷‍♂ 

The final item that we currently get from Travis integration is codecov support. Currently this doesn't work in a nice way with GitHub actions (it only works from the same repo, and you need to add a secret iirc). However, I've read recently that they may be updating their GitHub action to provide this functionality in the not too distant future. 