### PR TITLE
Improve test coverage

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -253,8 +253,13 @@ class FormHelper(DynamicLayoutHandler):
         if self._form_style == "default":
             return ""
 
-        if self._form_style == "inline":
+        elif self._form_style == "inline":
             return "inlineLabels"
+
+        else:
+            raise FormHelpersException(
+                "Invalid _form_style has been set. Only default and inline are valid attributes"
+            )
 
     @form_style.setter
     def form_style(self, style):

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -184,15 +184,15 @@ def crispy_addon(field, append="", prepend="", form_show_labels=True):
         {% crispy_addon form.my_field prepend="$" %}
         {% crispy_addon form.my_field append=".00" %}
     """
-    if field:
-        context = Context({"field": field, "form_show_errors": True, "form_show_labels": form_show_labels})
-        template = loader.get_template("%s/layout/prepended_appended_text.html" % get_template_pack())
-        context["crispy_prepended_text"] = prepend
-        context["crispy_appended_text"] = append
 
-        if not prepend and not append:
-            raise TypeError("Expected a prepend and/or append argument")
+    context = Context({"field": field, "form_show_errors": True, "form_show_labels": form_show_labels})
+    template = loader.get_template("%s/layout/prepended_appended_text.html" % get_template_pack())
+    context["crispy_prepended_text"] = prepend
+    context["crispy_appended_text"] = append
 
-        context = context.flatten()
+    if not prepend and not append:
+        raise TypeError("Expected a prepend and/or append argument")
+
+    context = context.flatten()
 
     return template.render(context)

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -108,7 +108,6 @@ def as_crispy_field(field, template_pack=TEMPLATE_PACK, label_class="", field_cl
         "field_class": field_class,
     }
     helper = getattr(field.form, "helper", None)
-
     template_path = None
     if helper is not None:
         attributes.update(helper.get_attributes(template_pack))

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -98,8 +98,7 @@ class BasicNode(template.Node):
 
         # use template_pack from helper, if defined
         try:
-            if helper.template_pack:
-                self.template_pack = helper.template_pack
+            self.template_pack = helper.template_pack
         except AttributeError:
             pass
 

--- a/crispy_forms/tests/forms.py
+++ b/crispy_forms/tests/forms.py
@@ -144,3 +144,8 @@ class SampleForm8(forms.ModelForm):
     class Meta:
         model = CrispyTestModel
         fields = ("email", "password2", "password")
+
+
+class SampleFileFieldForm(forms.Form):
+    file = forms.FileField(widget=forms.FileInput)
+    clearable_file = forms.FileField(widget=forms.ClearableFileInput)

--- a/crispy_forms/tests/test_dynamic_api.py
+++ b/crispy_forms/tests/test_dynamic_api.py
@@ -76,6 +76,9 @@ def test_wrap_together_with_slices():
     assert layout.fields[1] == "password1"
     assert layout.fields[2] == "password2"
 
+    with pytest.raises(DynamicError):
+        helper.filter(Field).wrap_together(Field, css_class="error_class")
+
 
 def test_wrap_together_partial_slices():
     helper = FormHelper()
@@ -104,6 +107,9 @@ def test_update_attributes():
     helper.layout = Layout("email", Field("password1"), "password2",)
     helper["password1"].update_attributes(readonly=True)
     assert "readonly" in helper.layout[1].attrs
+
+    helper[1].update_attributes(readonly=False)
+    assert helper.layout[1].attrs == {"readonly": False}
 
 
 def test_update_attributes_and_wrap_once():

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -2,7 +2,6 @@ import re
 
 import pytest
 
-import django
 from django import forms
 from django.forms.models import formset_factory
 from django.middleware.csrf import _get_new_csrf_string
@@ -146,10 +145,7 @@ def test_html5_required():
     form.helper.html5_required = True
     html = render_crispy_form(form)
     # 6 out of 7 fields are required and an extra one for the SplitDateTimeWidget makes 7.
-    if django.VERSION < (1, 10):
-        assert html.count('required="required"') == 7
-    else:
-        assert len(re.findall(r"\brequired\b", html)) == 7
+    assert len(re.findall(r"\brequired\b", html)) == 7
 
     form = SampleForm()
     form.helper = FormHelper()
@@ -929,3 +925,20 @@ def test_bootstrap3_does_not_add_form_control_class_to_multivaluefield():
     form.helper.template_pack = "bootstrap3"
     html = render_crispy_form(form)
     assert "form-control" not in html
+
+
+def test_form_style_setter():
+    form = SampleForm()
+    form.helper = FormHelper()
+    with pytest.raises(FormHelpersException):
+        form.helper.form_style = "typo"
+
+    form.helper.form_style = "inline"
+    assert form.helper.form_style == "inlineLabels"
+
+    form.helper.form_style = "default"
+    assert form.helper.form_style == ""
+
+    form.helper._form_style = "error"
+    with pytest.raises(FormHelpersException):
+        assert form.helper.form_style == "error"

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -18,6 +18,7 @@ from .forms import (
     CheckboxesSampleForm,
     CrispyEmptyChoiceTestModel,
     CrispyTestModel,
+    SampleFileFieldForm,
     SampleForm,
     SampleForm2,
     SampleForm3,
@@ -80,7 +81,7 @@ def test_meta_extra_fields_with_missing_fields():
     assert "email" not in html
 
 
-def test_layout_unresolved_field(settings):
+def test_layout_unresolved_field(settings, caplog):
     form_helper = FormHelper()
     form_helper.add_layout(Layout("typo"))
 
@@ -94,6 +95,10 @@ def test_layout_unresolved_field(settings):
     settings.CRISPY_FAIL_SILENTLY = False
     with pytest.raises(Exception):
         template.render(c)
+
+    settings.CRISPY_FAIL_SILENTLY = True
+    template.render(c)
+    assert caplog.record_tuples[0][2] == "Could not resolve form field 'typo'."
 
 
 def test_double_rendered_field(settings):
@@ -550,6 +555,30 @@ def test_use_custom_control_is_used():
     assert response.content.count(b"form-check-inline") == 3
     assert response.content.count(b"form-check") > 0
     assert response.content.count(b"custom-checkbox") == 0
+
+
+@only_bootstrap4
+def test_file_field():
+    form = SampleFileFieldForm()
+    form.helper = FormHelper()
+    form.helper.layout = Layout("file", "clearable_file")
+    form.helper.layout = Layout("file", "clearable_file")
+    # form.helper.use_custom_control take default value which is True
+
+    html = render_crispy_form(form)
+    assert 'class="fileinput fileUpload form-control-file custom-file-input"' in html
+    assert 'class="clearablefileinput form-control-file"' in html
+
+    form2 = SampleFileFieldForm()
+    form2.helper = FormHelper()
+    form2.helper.layout = Layout("file", "clearable_file")
+    form2.helper.layout = Layout("file", "clearable_file")
+
+    form2.helper.use_custom_control = False
+
+    html = render_crispy_form(form2)
+    assert 'class="fileinput fileUpload form-control-file"' in html
+    assert 'class="clearablefileinput form-control-file"' in html
 
 
 @only_bootstrap3

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -508,38 +508,23 @@ class TestBootstrapLayoutObjects:
             )
             assert html.strip() == expected
         if settings.CRISPY_TEMPLATE_PACK == "bootstrap3":
-            if sys.version_info >= (3, 6, 0):  # Input order is different in python 3.5
+            if sys.version_info >= (3, 6, 0):  # Dictionaries are unordered in python 3.5
                 expected = (
                     '<form  method="post" > <div id="div_id_is_company" class="form-group"> '
                     '<label class="control-label ">company</label> <div class="controls "> '
                     '<input type="checkbox" name="is_company" class="uneditable-input checkboxinput" '
                     'disabled="disabled" id="id_is_company"> </div>\n</div> </form>'
                 )
-            else:
-                expected = (
-                    '<form  method="post" > <div id="div_id_is_company" class="form-group"> '
-                    '<label class="control-label ">company</label> <div class="controls "> '
-                    '<input type="checkbox" name="is_company" id="id_is_company" disabled="disabled" '
-                    'class="uneditable-input checkboxinput"> </div>\n</div> </form>'
-                )
-            assert html.strip() == expected
+                assert html.strip() == expected
         if settings.CRISPY_TEMPLATE_PACK == "bootstrap4":
-            if sys.version_info >= (3, 6, 0):  # Input order is different in python 3.5
+            if sys.version_info >= (3, 6, 0):  # Dictionaries are unordered in python 3.5
                 expected = (
                     '<form  method="post" > <div id="div_id_is_company" class="form-group"> '
                     '<label class="">company</label> <div class=""> <input type="checkbox" '
                     'name="is_company" class="uneditable-input checkboxinput" disabled="disabled" '
                     'id="id_is_company"> </div>\n</div> </form>'
                 )
-            else:
-                expected = (
-                    '<form  method="post" > <div id="div_id_is_company" class="form-group"> '
-                    '<label class="">company</label> <div class=""> <input type="checkbox" '
-                    'name="is_company" id="id_is_company" disabled="disabled" class="uneditable-input checkboxinput"> '
-                    "</div>\n</div> </form>"
-                )
-
-            assert html.strip() == expected
+                assert html.strip() == expected
 
     def test_formactions(self, settings):
         test_form = SampleForm()

--- a/crispy_forms/tests/test_tags.py
+++ b/crispy_forms/tests/test_tags.py
@@ -1,5 +1,6 @@
 import pytest
 
+import django
 from django.forms.boundfield import BoundField
 from django.forms.formsets import formset_factory
 from django.template import Context, Template
@@ -112,9 +113,12 @@ def test_as_crispy_field_non_field(settings):
 
     # Raises an AttributeError when trying to figure out how to render it
     # Not sure if this is expected behavior -- @kavdev
-    error_class = CrispyError if settings.DEBUG else AttributeError
+    with pytest.raises(AttributeError):
+        template.render(c)
 
-    with pytest.raises(error_class):
+    django.conf.settings.DEBUG = True
+
+    with pytest.raises(CrispyError):
         template.render(c)
 
 


### PR DESCRIPTION
This pull request adds a number of tests for areas of the project which currently don't have test coverage (e.g. formactions/ uneditable field / file field)

I've also made a few amendments to some `if` statements which are not needed and so have removed these. 

The final change I made was to `helper.py` to raise an error if somehow _form_style is incorrectly set. Complete, with a test of course. 😄 

By my workings this should get a small increase in test coverage from 97% to 99%. 