### PR TITLE
Run tests with django_coverage_plugin

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+plugins =
+    django_coverage_plugin
+source =
+    crispy_forms
+omit =
+    */.tox/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ python:
 cache: pip
 
 install:
-  - pip install coverage tox-travis tox-venv
+  - pip install coverage tox-travis tox-venv django_coverage_plugin
 
 script:
-  - coverage erase
   - tox
 
 after_success:
+  - pip install Django
   - coverage combine --append
   - coverage report -m
   - pip install codecov

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: develop test
 
 develop:
-	pip install -q -r requirements.txt
-	pip install -q -e .
+	pip3 install -q -r requirements.txt
+	pip3 install -q -e .
 
 test: develop
-	DJANGO_SETTINGS_MODULE=crispy_forms.tests.test_settings py.test crispy_forms/tests --cov=crispy_forms
+	coverage run -m pytest --ds=crispy_forms.tests.test_settings

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 pytest-cov
 pytest-django
 pre-commit
+django_coverage_plugin


### PR DESCRIPTION
I came across django_coverage_plugin and thought it would be interesting to see it applied to this project. 

It's interesting in that it shows we have really low coverage for the templates, particularly the bootstrap ones. If we merge, would we then look to increase coverage in these areas - be it removal of unused templates, or adding new tests. 

I'm expecting coverage to drop in to the 80% range. Let's see if and how codecov responds as I've re-written how travis runs the tests. 

Thoughts? 
