### PR TITLE
Remove bs3 styles from crispy_forms_field

### DIFF
--- a/crispy_forms/templates/bootstrap3/field.html
+++ b/crispy_forms/templates/bootstrap3/field.html
@@ -33,7 +33,11 @@
                 {% include 'bootstrap3/layout/help_text_and_errors.html' %}
             {% else %}
                 <div class="controls {{ field_class }}">
-                    {% crispy_field field %}
+                    {% if field|is_multivalue %}
+                        {% crispy_field field %}
+                    {% else %}    
+                        {% crispy_field field 'class' 'form-control' %}
+                    {% endif %}    
                     {% include 'bootstrap3/layout/help_text_and_errors.html' %}
                 </div>
             {% endif %}

--- a/crispy_forms/templates/bootstrap3/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap3/layout/prepended_appended_text.html
@@ -14,7 +14,7 @@
         <div class="controls {{ field_class }}">
             <div class="input-group">
                 {% if crispy_prepended_text %}<span class="input-group-addon{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_prepended_text|safe }}</span>{% endif %}
-                {% crispy_field field %}
+                {% crispy_field field 'class' 'form-control' %}
                 {% if crispy_appended_text %}<span class="input-group-addon{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ crispy_appended_text|safe }}</span>{% endif %}
             </div>
 

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -121,16 +121,6 @@ class CrispyFieldNode(template.Node):
             else:
                 css_class = class_name
 
-            if (
-                template_pack == "bootstrap3"
-                and not is_checkbox(field)
-                and not is_file(field)
-                and not is_multivalue(field)
-            ):
-                css_class += " form-control"
-                if field.errors:
-                    css_class += " form-control-danger"
-
             if template_pack == "bootstrap4" and not is_multivalue(field):
                 if not is_checkbox(field):
                     css_class += " form-control"


### PR DESCRIPTION
Here is another step towards decoupling _crispy-forms-core_ from template packs. 

This removes the bs3 styles which are currently being added in `crispy_forms_field.py`. 

Interestingly, and at least from what I can see in the docs, `form-control-danger` is not the right way of adding errors in bs3. 'has-error' is the solution and that's already built into the templates. This made it much easier to put the remaining logic into the templates. I suspect the bs4 templates will not be quite so easy.

Here are before/after images (no change hopefully) 🤞 

Before:
![before](https://user-images.githubusercontent.com/39445562/76171509-33271c80-6184-11ea-95e3-518db2748d4d.png)

After: 
![after](https://user-images.githubusercontent.com/39445562/76171512-39b59400-6184-11ea-8cc0-33afaafff5c5.png)
