### PR TITLE
Improve pattern to encompass BS4 css col class such as col-4

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -1,12 +1,11 @@
 import re
 
-from django.urls import NoReverseMatch, reverse
-from django.utils.safestring import mark_safe
-
 from crispy_forms.exceptions import FormHelpersException
 from crispy_forms.layout import Layout
 from crispy_forms.layout_slice import LayoutSlice
 from crispy_forms.utils import TEMPLATE_PACK, flatatt, list_difference, render_field
+from django.urls import NoReverseMatch, reverse
+from django.utils.safestring import mark_safe
 
 
 class DynamicLayoutHandler:
@@ -337,10 +336,10 @@ class FormHelper(DynamicLayoutHandler):
 
         if template_pack == "bootstrap4":
             if "form-horizontal" in self.form_class.split():
-                bootstrap_size_match = re.findall(r"col-(xl|lg|md|sm)-(\d+)", self.label_class)
+                bootstrap_size_match = re.findall(r"col(-(xl|lg|md|sm))?-(\d+)", self.label_class)
                 if bootstrap_size_match:
-                    offset_pattern = "offset-%s-%s"
-                    items["bootstrap_checkbox_offsets"] = [offset_pattern % m for m in bootstrap_size_match]
+                    offset_pattern = "offset%s-%s"
+                    items["bootstrap_checkbox_offsets"] = [offset_pattern % (m[0], m[-1]) for m in bootstrap_size_match]
         else:
             bootstrap_size_match = re.findall(r"col-(lg|md|sm|xs)-(\d+)", self.label_class)
             if bootstrap_size_match:

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -339,7 +339,9 @@ class FormHelper(DynamicLayoutHandler):
                 bootstrap_size_match = re.findall(r"col(-(xl|lg|md|sm))?-(\d+)", self.label_class)
                 if bootstrap_size_match:
                     offset_pattern = "offset%s-%s"
-                    items["bootstrap_checkbox_offsets"] = [offset_pattern % (m[0], m[-1]) for m in bootstrap_size_match]
+                    items["bootstrap_checkbox_offsets"] = [
+                        offset_pattern % (m[0], m[-1]) for m in bootstrap_size_match
+                    ]
         else:
             bootstrap_size_match = re.findall(r"col-(lg|md|sm|xs)-(\d+)", self.label_class)
             if bootstrap_size_match:

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -863,25 +863,18 @@ def test_label_class_and_field_class_bs4_offset_when_horizontal():
     assert '<div class="offset-lg-2 col-lg-8">' in html
     assert html.count("col-lg-8") == 7
 
-    # Test multi col-XX-YY pattern
+    # Test multi col-XX-YY pattern and col-X pattern
 
-    form.helper.label_class = "col-sm-3 col-md-4"
-    form.helper.field_class = "col-sm-8 col-md-6"
+    form.helper.label_class = "col-sm-3 col-md-4 col-5 col-lg-4"
+    form.helper.field_class = "col-sm-8 col-md-6 col-7 col-lg-8"
     html = render_crispy_form(form)
 
     assert '<div class="form-group row">' in html
-    assert '<div class="offset-sm-3 offset-md-4 col-sm-8 col-md-6">' in html
+    assert '<div class="offset-sm-3 offset-md-4 offset-5 offset-lg-4 col-sm-8 col-md-6 col-7 col-lg-8">' in html
     assert html.count("col-sm-8") == 7
-
-    # Test col-X pattern
-
-    form.helper.label_class = "col-5 col-lg-4"
-    form.helper.field_class = "col-7 col-lg-8"
-    html = render_crispy_form(form)
-
-    assert '<div class="form-group row">' in html
-    assert '<div class="offset-5 offset-lg-4 col-7 col-lg-8">' in html
+    assert html.count("col-md-6") == 7
     assert html.count("col-7") == 7
+    assert html.count("col-lg-8") == 7
 
 
 @only_bootstrap4

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -851,6 +851,7 @@ def test_label_class_and_field_class_bs4():
 
 @only_bootstrap4
 def test_label_class_and_field_class_bs4_offset_when_horizontal():
+    # Test col-XX-YY pattern
     form = SampleForm()
     form.helper = FormHelper()
     form.helper.label_class = "col-lg-2"
@@ -862,6 +863,8 @@ def test_label_class_and_field_class_bs4_offset_when_horizontal():
     assert '<div class="offset-lg-2 col-lg-8">' in html
     assert html.count("col-lg-8") == 7
 
+    # Test multi col-XX-YY pattern
+
     form.helper.label_class = "col-sm-3 col-md-4"
     form.helper.field_class = "col-sm-8 col-md-6"
     html = render_crispy_form(form)
@@ -869,6 +872,16 @@ def test_label_class_and_field_class_bs4_offset_when_horizontal():
     assert '<div class="form-group row">' in html
     assert '<div class="offset-sm-3 offset-md-4 col-sm-8 col-md-6">' in html
     assert html.count("col-sm-8") == 7
+
+    # Test col-X pattern
+
+    form.helper.label_class = "col-5 col-lg-4"
+    form.helper.field_class = "col-7 col-lg-8"
+    html = render_crispy_form(form)
+
+    assert '<div class="form-group row">' in html
+    assert '<div class="offset-5 offset-lg-4 col-7 col-lg-8">' in html
+    assert html.count("col-7") == 7
 
 
 @only_bootstrap4


### PR DESCRIPTION
When using horizontal form like in crispy test project, allow to use col-4 is not only col-sm-4:

```
class HorizontalMessageForm(forms.Form):
    (...)

    helper = FormHelper()
    (...)
    helper.form_class = 'form-horizontal'
    helper.label_class = 'col-4'
    helper.field_class = 'col-8'
```


Before:
![Capture d’écran de 2020-03-19 15-34-43](https://user-images.githubusercontent.com/11556772/77078730-472a1400-69f7-11ea-8c4a-3d61cae2e92d.png)
Fixe:
![Capture d’écran de 2020-03-19 15-35-03](https://user-images.githubusercontent.com/11556772/77078733-47c2aa80-69f7-11ea-96b9-f842237d3e43.png)
