### PR TITLE
Tailwind support!

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -211,6 +211,7 @@ class FormHelper(DynamicLayoutHandler):
     label_class = ""
     field_class = ""
     include_media = True
+    css_container = None
 
     def __init__(self, form=None):
         self.attrs = {}
@@ -333,6 +334,7 @@ class FormHelper(DynamicLayoutHandler):
             "include_media": self.include_media,
             "label_class": self.label_class,
             "use_custom_control": self.use_custom_control,
+            "css_container": self.css_container
         }
 
         if template_pack == "bootstrap4":

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -334,7 +334,7 @@ class FormHelper(DynamicLayoutHandler):
             "include_media": self.include_media,
             "label_class": self.label_class,
             "use_custom_control": self.use_custom_control,
-            "css_container": self.css_container
+            "css_container": self.css_container,
         }
 
         if template_pack == "bootstrap4":

--- a/crispy_forms/tailwind.py
+++ b/crispy_forms/tailwind.py
@@ -1,0 +1,79 @@
+import re
+
+from django.template import Library
+
+register = Library()
+
+default = {"base": "test default css", "text": "some text", "radioselect": "radio"}
+
+default_radioselect = {
+    "input": "test radio css",
+}
+
+checkbox = {
+    "checkbox": "checkbox",
+}
+
+
+class CSSContainer:
+    def __init__(self, css_styles):
+        default_items = [
+            "text",
+            "number",
+            "email",
+            "url",
+            "password",
+            "hidden",
+            "multiplehidden",
+            "file",
+            "clearablefile",
+            "textarea",
+            "date",
+            "datetime",
+            "time",
+            "checkbox",
+            "select",
+            "nullbooleanselect",
+            "selectmultiple",
+            "radioselect",
+            "checkboxselectmultiple",
+            "multi",
+            "splitdatetime",
+            "splithiddendatetime",
+            "selectdate",
+        ]
+
+        base = css_styles.get("base", "")
+        for item in default_items:
+            setattr(self, item, base)
+
+        for key, value in css_styles.items():
+            if key != "base":
+                # get current attribute and rejoin with a set, also to ensure a space between each attribute
+                current_class = set(getattr(self, key).split())
+                current_class.update(set(value.split()))
+                new_classes = " ".join(current_class)
+                setattr(self, key, new_classes)
+
+    def __repr__(self):
+        return str(self.__dict__)
+
+    def __add__(self, other):
+        for field, css_class in other.items():
+            current_class = set(getattr(self, field).split())
+            current_class.update(set(css_class.split()))
+            new_classes = " ".join(current_class)
+            setattr(self, field, new_classes)
+        return self
+
+    def __sub__(self, other):
+        for field, css_class in other.items():
+            current_class = set(getattr(self, field).split())
+            removed_classes = set(css_class.split())
+            new_classes = " ".join(current_class - removed_classes)
+            setattr(self, field, new_classes)
+        return self
+
+    def get_input_class(self, field):
+        widget_name = re.sub(r"widget$|input$", "", field.field.widget.__class__.__name__.lower())
+        return getattr(self, widget_name)

--- a/crispy_forms/templates/tailwind/betterform.html
+++ b/crispy_forms/templates/tailwind/betterform.html
@@ -1,0 +1,21 @@
+{% for fieldset in form.fieldsets %}
+    <fieldset class="fieldset-{{ forloop.counter }} {{ fieldset.classes }}">
+        {% if fieldset.legend %}
+            <legend>{{ fieldset.legend }}</legend>
+        {% endif %}
+
+        {% if fieldset.description %}
+            <p class="description">{{ fieldset.description }}</p>
+        {% endif %}
+
+        {% for field in fieldset %}
+            {% if field.is_hidden %}
+                {{ field }}
+            {% else %}
+                {% include "tailwind/field.html" %}
+            {% endif %}
+        {% endfor %}
+    {% if not forloop.last or not fieldset_open %}
+        </fieldset>
+    {% endif %}
+{% endfor %}

--- a/crispy_forms/templates/tailwind/display_form.html
+++ b/crispy_forms/templates/tailwind/display_form.html
@@ -1,0 +1,9 @@
+{% if form.form_html %}
+    {% if include_media %}{{ form.media }}{% endif %}
+    {% if form_show_errors %}
+        {% include "tailwind/errors.html" %}
+    {% endif %}
+    {{ form.form_html }}
+{% else %}
+    {% include "tailwind/uni_form.html" %}
+{% endif %}

--- a/crispy_forms/templates/tailwind/errors.html
+++ b/crispy_forms/templates/tailwind/errors.html
@@ -1,0 +1,8 @@
+{% if form.non_field_errors %}
+    <div class="alert alert-block alert-danger">
+        {% if form_error_title %}<h4 class="alert-heading">{{ form_error_title }}</h4>{% endif %}
+        <ul class="m-0">
+            {{ form.non_field_errors|unordered_list }}
+        </ul>
+    </div>
+{% endif %}

--- a/crispy_forms/templates/tailwind/errors_formset.html
+++ b/crispy_forms/templates/tailwind/errors_formset.html
@@ -1,0 +1,8 @@
+{% if formset.non_form_errors %}
+    <div class="alert alert-block alert-danger">
+        {% if formset_error_title %}<h4 class="alert-heading">{{ formset_error_title }}</h4>{% endif %}
+        <ul class="m-0">
+            {{ formset.non_form_errors|unordered_list }}
+        </ul>
+    </div>
+{% endif %}

--- a/crispy_forms/templates/tailwind/field.html
+++ b/crispy_forms/templates/tailwind/field.html
@@ -1,0 +1,33 @@
+{% load crispy_forms_field %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    {# Opening Div and Label first#}
+    
+        <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field_class %} {{ field_class }}{% endif %}">
+            {% if field.label and form_show_labels %}
+                <label for="{{ field.id_for_label }}" class="{{ label_class }}">
+                    {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                </label>
+            {% endif %}
+        
+        {# if field has a special template then use this #}
+    {% if field|is_radioselect %}
+        <div class="{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+
+        {% include 'tailwind/layout/radioselect.html' %}
+    {% elif field|is_checkboxselectmultiple %}
+            
+<div class="{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+        {% include 'tailwind/layout/checkboxselectmultiple.html' %}
+    {% else %}
+        
+        {# otherwise use django rendering with additional classes added #}
+            {% crispy_field field %}
+
+            {% include 'tailwind/layout/help_text_and_errors.html' %}
+
+        </{% if tag %}{{ tag }}{% else %}div{% endif %}>
+    {% endif %}
+{% endif %}

--- a/crispy_forms/templates/tailwind/inputs.html
+++ b/crispy_forms/templates/tailwind/inputs.html
@@ -1,0 +1,13 @@
+{% if inputs %}
+    <div class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}">
+        {% if label_class %}
+            <div class="aab {{ label_class }}"></div>
+        {% endif %}
+
+        <div class="{{ field_class }}">
+            {% for input in inputs %}
+                {% include "tailwind/layout/baseinput.html" %}
+            {% endfor %}
+        </div>
+    </div>
+{% endif %}

--- a/crispy_forms/templates/tailwind/layout/alert.html
+++ b/crispy_forms/templates/tailwind/layout/alert.html
@@ -1,0 +1,4 @@
+<div{% if alert.css_id %} id="{{ alert.css_id }}"{% endif %}{% if alert.css_class %} class="{{ alert.css_class }}"{% endif %}>
+    {% if dismiss %}<button type="button" class="close" data-dismiss="alert">&times;</button>{% endif %}
+    {{ content|safe }}
+</div>

--- a/crispy_forms/templates/tailwind/layout/baseinput.html
+++ b/crispy_forms/templates/tailwind/layout/baseinput.html
@@ -1,0 +1,9 @@
+<input type="{{ input.input_type }}"
+    name="{% if input.name|wordcount > 1 %}{{ input.name|slugify }}{% else %}{{ input.name }}{% endif %}"
+    value="{{ input.value }}"
+    {% if input.input_type != "hidden" %}
+        class="{{ input.field_classes }}"
+        id="{% if input.id %}{{ input.id }}{% else %}{{ input.input_type }}-id-{{ input.name|slugify }}{% endif %}"
+    {% endif %}
+    {{ input.flat_attrs|safe }}
+    />

--- a/crispy_forms/templates/tailwind/layout/button.html
+++ b/crispy_forms/templates/tailwind/layout/button.html
@@ -1,0 +1,1 @@
+<button {{ button.flat_attrs|safe }}>{{ button.content|safe }}</button>

--- a/crispy_forms/templates/tailwind/layout/buttonholder.html
+++ b/crispy_forms/templates/tailwind/layout/buttonholder.html
@@ -1,0 +1,4 @@
+<div {% if buttonholder.css_id %}id="{{ buttonholder.css_id }}"{% endif %} 
+    class="buttonHolder{% if buttonholder.css_class %} {{ buttonholder.css_class }}{% endif %}">
+       {{ fields_output|safe }}
+</div>

--- a/crispy_forms/templates/tailwind/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/tailwind/layout/checkboxselectmultiple.html
@@ -1,0 +1,17 @@
+{% load crispy_forms_filters %}
+{% load l10n %}
+
+
+    {% for choice in field.field.choices %}
+        <div class="mr-3">
+            <label class="{{ css_container.option_label }}" for="id_{{ field.html_name }}_{{ forloop.counter }}">
+                <input type="checkbox" class="{{ css_container.checkboxselectmultiple }}"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
+                {{ choice.1|unlocalize }}
+            </label>
+            {% if field.errors and forloop.last and not inline_class %}
+                {% include 'tailwind/layout/field_errors_block.html' %}
+            {% endif %}
+        </div>
+    {% endfor %}
+    {% include 'tailwind/layout/help_text.html' %}
+</div>

--- a/crispy_forms/templates/tailwind/layout/checkboxselectmultiple_inline.html
+++ b/crispy_forms/templates/tailwind/layout/checkboxselectmultiple_inline.html
@@ -1,0 +1,18 @@
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+             <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field_class %} {{ field_class }}{% endif %}">
+
+        {% if field.label %}
+            <label for="{{ field.id_for_label }}"  class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            </label>
+        {% endif %}
+             
+                 <div id="div_{{ field.auto_id }}" class="flex flex-row{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+
+ 
+
+        {% include 'tailwind/layout/checkboxselectmultiple.html' %}
+    </div>
+{% endif %}

--- a/crispy_forms/templates/tailwind/layout/column.html
+++ b/crispy_forms/templates/tailwind/layout/column.html
@@ -1,0 +1,4 @@
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %}
+     class="flex flex-row {{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+        {{ fields|safe }}
+</div>

--- a/crispy_forms/templates/tailwind/layout/div.html
+++ b/crispy_forms/templates/tailwind/layout/div.html
@@ -1,0 +1,4 @@
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
+    {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
+        {{ fields|safe }}
+</div>

--- a/crispy_forms/templates/tailwind/layout/field_errors.html
+++ b/crispy_forms/templates/tailwind/layout/field_errors.html
@@ -1,0 +1,5 @@
+{% if form_show_errors and field.errors %}
+    {% for error in field.errors %}
+        <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="text-red-600"><strong>{{ error }}</strong></p>
+    {% endfor %}
+{% endif %}

--- a/crispy_forms/templates/tailwind/layout/field_errors_block.html
+++ b/crispy_forms/templates/tailwind/layout/field_errors_block.html
@@ -1,0 +1,5 @@
+{% if form_show_errors and field.errors %}
+    {% for error in field.errors %}
+        <p id="error_{{ forloop.counter }}_{{ field.auto_id }}" class="text-red-600"><strong>{{ error }}</strong></p>
+    {% endfor %}
+{% endif %}

--- a/crispy_forms/templates/tailwind/layout/field_with_buttons.html
+++ b/crispy_forms/templates/tailwind/layout/field_with_buttons.html
@@ -1,0 +1,17 @@
+{% load crispy_forms_field %}
+
+<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
+    {% if field.label and form_show_labels %}
+        <label for="{{ field.id_for_label }}" class="{% if 'form-horizontal' in form_class %}col-form-label {% endif %}{{ label_class }}{% if field.field.required %} requiredField{% endif %}">
+            {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+        </label>
+    {% endif %}
+
+    <div class="{{ field_class }}">
+        <div class="input-group">
+            {% crispy_field field %}
+            <span class="input-group-append{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ buttons|safe }}</span>
+        </div>
+        {% include 'tailwind/layout/help_text_and_errors.html' %}
+    </div>
+</div>

--- a/crispy_forms/templates/tailwind/layout/fieldset.html
+++ b/crispy_forms/templates/tailwind/layout/fieldset.html
@@ -1,0 +1,6 @@
+<fieldset {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %} 
+    {% if fieldset.css_class or form_style %}class="{{ fieldset.css_class }} {{ form_style }}"{% endif %}
+    {{ fieldset.flat_attrs|safe }}>
+    {% if legend %}<legend>{{ legend|safe }}</legend>{% endif %}
+    {{ fields|safe }} 
+</fieldset>

--- a/crispy_forms/templates/tailwind/layout/formactions.html
+++ b/crispy_forms/templates/tailwind/layout/formactions.html
@@ -1,0 +1,9 @@
+<div{% if formactions.attrs %} {{ formactions.flat_attrs|safe }}{% endif %} class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}">
+    {% if label_class %}
+        <div class="aab {{ label_class }}"></div>
+    {% endif %}
+
+    <div class="{{ field_class }}">
+        {{ fields_output|safe }}
+    </div>
+</div>

--- a/crispy_forms/templates/tailwind/layout/help_text.html
+++ b/crispy_forms/templates/tailwind/layout/help_text.html
@@ -1,0 +1,7 @@
+{% if field.help_text %}
+    {% if help_text_inline %}
+        <p id="hint_{{ field.auto_id }}" class="text-gray-600">{{ field.help_text|safe }}</p>x
+    {% else %}
+        <small id="hint_{{ field.auto_id }}" class="text-gray-600">{{ field.help_text|safe }}</small>
+    {% endif %}
+{% endif %}

--- a/crispy_forms/templates/tailwind/layout/help_text_and_errors.html
+++ b/crispy_forms/templates/tailwind/layout/help_text_and_errors.html
@@ -1,0 +1,13 @@
+{% if help_text_inline and not error_text_inline %}
+    {% include 'tailwind/layout/help_text.html' %}
+{% endif %}
+
+{% if error_text_inline %}
+    {% include 'tailwind/layout/field_errors.html' %}
+{% else %}
+    {% include 'tailwind/layout/field_errors_block.html' %}
+{% endif %}
+
+{% if not help_text_inline %}
+    {% include 'tailwind/layout/help_text.html' %}
+{% endif %}

--- a/crispy_forms/templates/tailwind/layout/inline_field.html
+++ b/crispy_forms/templates/tailwind/layout/inline_field.html
@@ -1,0 +1,21 @@
+{% load crispy_forms_field %}
+
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+    {% if field|is_checkbox %}
+        <div id="div_{{ field.auto_id }}" class="form-check form-check-inline{% if wrapper_class %} {{ wrapper_class }}{% endif %}">
+            <label for="{{ field.id_for_label }}" class="form-check-label{% if field.field.required %} requiredField{% endif %}">
+                {% crispy_field field 'class' 'form-check-input' %}
+                {{ field.label|safe }}
+            </label>
+        </div>
+    {% else %}
+        <div id="div_{{ field.auto_id }}" class="input-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}">
+            <label for="{{ field.id_for_label }}" class="sr-only{% if field.field.required %} requiredField{% endif %}">
+                {{ field.label|safe }}
+            </label>
+            {% crispy_field field 'placeholder' field.label %}
+        </div>
+    {% endif %}
+{% endif %}

--- a/crispy_forms/templates/tailwind/layout/radioselect.html
+++ b/crispy_forms/templates/tailwind/layout/radioselect.html
@@ -1,0 +1,16 @@
+{% load crispy_forms_filters %}
+{% load l10n %}
+
+
+    {% for choice in field.field.choices %}
+            <label for="id_{{ field.html_name }}_{{ forloop.counter }}" class="{{ css_container.option_label }} mr-3">
+                <input type="radio" class="{{ css_container.radioselect }}"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {{ field.field.widget.attrs|flatatt }}>
+                {{ choice.1|unlocalize }}
+            </label>
+                    {% if field.errors and forloop.last %}
+                {% include 'tailwind/layout/field_errors_block.html' %}
+            {% endif %}
+            
+    {% endfor %}
+    {% include 'tailwind/layout/help_text.html' %} 
+    </div>

--- a/crispy_forms/templates/tailwind/layout/radioselect_inline.html
+++ b/crispy_forms/templates/tailwind/layout/radioselect_inline.html
@@ -1,0 +1,16 @@
+{% if field.is_hidden %}
+    {{ field }}
+{% else %}
+             <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" class="{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field_class %} {{ field_class }}{% endif %}">
+
+        {% if field.label %}
+            <label for="{{ field.id_for_label }}"  class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
+                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            </label>
+        {% endif %}
+
+    <div id="div_{{ field.auto_id }}" class="flex flex-row{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+
+        {% include 'tailwind/layout/radioselect.html' %}
+    </div>
+{% endif %}

--- a/crispy_forms/templates/tailwind/layout/row.html
+++ b/crispy_forms/templates/tailwind/layout/row.html
@@ -1,0 +1,3 @@
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="{{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+        {{ fields|safe }}
+</div>

--- a/crispy_forms/templates/tailwind/table_inline_formset.html
+++ b/crispy_forms/templates/tailwind/table_inline_formset.html
@@ -1,0 +1,57 @@
+{% load crispy_forms_tags %}
+{% load crispy_forms_utils %}
+{% load crispy_forms_field %}
+
+{% specialspaceless %}
+{% if formset_tag %}
+<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
+{% endif %}
+    {% if formset_method|lower == 'post' and not disable_csrf %}
+        {% csrf_token %}
+    {% endif %}
+
+    <div>
+        {{ formset.management_form|crispy }}
+    </div>
+
+    <table{% if form_id %} id="{{ form_id }}_table"{% endif%} class="table table-striped table-sm">
+        <thead>
+            {% if formset.readonly and not formset.queryset.exists %}
+            {% else %}
+                <tr>
+                    {% for field in formset.forms.0 %}
+                        {% if field.label and not field.is_hidden %}
+                            <th for="{{ field.auto_id }}" class="col-form-label {% if field.field.required %}requiredField{% endif %}">
+                                {{ field.label|safe }}{% if field.field.required and not field|is_checkbox %}<span class="asteriskField">*</span>{% endif %}
+                            </th>
+                        {% endif %}
+                    {% endfor %}
+                </tr>
+            {% endif %}
+        </thead>
+
+        <tbody>
+            <tr class="d-none empty-form">
+                {% for field in formset.empty_form %}
+                    {% include 'tailwind/field.html' with tag="td" form_show_labels=False %}
+                {% endfor %}
+            </tr>
+
+            {% for form in formset %}
+                {% if form_show_errors and not form.is_extra %}
+                    {% include "tailwind/errors.html" %}
+                {% endif %}
+
+                <tr>
+                    {% for field in form %}
+                        {% include 'tailwind/field.html' with tag="td" form_show_labels=False %}
+                    {% endfor %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    {% include "tailwind/inputs.html" %}
+
+{% if formset_tag %}</form>{% endif %}
+{% endspecialspaceless %}

--- a/crispy_forms/templates/tailwind/uni_form.html
+++ b/crispy_forms/templates/tailwind/uni_form.html
@@ -1,0 +1,11 @@
+{% load crispy_forms_utils %}
+
+{% specialspaceless %}
+    {% if include_media %}{{ form.media }}{% endif %}
+    {% if form_show_errors %}
+        {% include "tailwind/errors.html" %}
+    {% endif %}
+    {% for field in form %}
+        {% include field_template %}
+    {% endfor %}
+{% endspecialspaceless %}

--- a/crispy_forms/templates/tailwind/uni_formset.html
+++ b/crispy_forms/templates/tailwind/uni_formset.html
@@ -1,0 +1,8 @@
+{% with formset.management_form as form %}
+    {% include 'tailwind/uni_form.html' %}
+{% endwith %}
+{% for form in formset %}
+    <div class="multiField">
+        {% include 'tailwind/uni_form.html' %}
+    </div>
+{% endfor %}

--- a/crispy_forms/templates/tailwind/whole_uni_form.html
+++ b/crispy_forms/templates/tailwind/whole_uni_form.html
@@ -1,0 +1,14 @@
+{% load crispy_forms_utils %}
+
+{% specialspaceless %}
+{% if form_tag %}<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>{% endif %}
+    {% if form_method|lower == 'post' and not disable_csrf %}
+        {% csrf_token %}
+    {% endif %}
+
+    {% include "tailwind/display_form.html" %}
+
+    {% include "tailwind/inputs.html" %}
+
+{% if form_tag %}</form>{% endif %}
+{% endspecialspaceless %}

--- a/crispy_forms/templates/tailwind/whole_uni_formset.html
+++ b/crispy_forms/templates/tailwind/whole_uni_formset.html
@@ -1,0 +1,30 @@
+{% load crispy_forms_tags %}
+{% load crispy_forms_utils %}
+
+{% specialspaceless %}
+{% if formset_tag %}
+<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
+{% endif %}
+    {% if formset_method|lower == 'post' and not disable_csrf %}
+        {% csrf_token %}
+    {% endif %}
+
+    <div>
+        {{ formset.management_form|crispy }}
+    </div>
+
+    {% include "tailwind/errors_formset.html" %}
+
+    {% for form in formset %}
+        {% include "tailwind/display_form.html" %}
+    {% endfor %}
+
+    {% if inputs %}
+        <div class="form-actions">
+            {% for input in inputs %}
+                {% include "tailwind/layout/baseinput.html" %}
+            {% endfor %}
+        </div>
+    {% endif %}
+{% if formset_tag %}</form>{% endif %}
+{% endspecialspaceless %}

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.template import Context, loader
 
 from crispy_forms.utils import TEMPLATE_PACK, get_template_pack
+from crispy_forms.tailwind import CSSContainer
 
 register = template.Library()
 
@@ -136,6 +137,12 @@ class CrispyFieldNode(template.Node):
                         css_class += "-file"
                 if field.errors:
                     css_class += " is-invalid"
+
+            if template_pack == "tailwind":
+                css_container = context.get("css_container")
+                if css_container:
+                    css = " " + css_container.get_input_class(field)
+                    css_class += css
 
             widget.attrs["class"] = css_class
 

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -3,7 +3,6 @@ from django.conf import settings
 from django.template import Context, loader
 
 from crispy_forms.utils import TEMPLATE_PACK, get_template_pack
-from crispy_forms.tailwind import CSSContainer
 
 register = template.Library()
 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -261,7 +261,7 @@ def do_uni_form(parser, token):
     if template_pack is not None:
         template_pack = template_pack[1:-1]
         ALLOWED_TEMPLATE_PACKS = getattr(
-            settings, "CRISPY_ALLOWED_TEMPLATE_PACKS", ("bootstrap", "uni_form", "bootstrap3", "bootstrap4")
+            settings, "CRISPY_ALLOWED_TEMPLATE_PACKS", ("bootstrap", "uni_form", "bootstrap3", "bootstrap4", "tailwind")
         )
         if template_pack not in ALLOWED_TEMPLATE_PACKS:
             raise template.TemplateSyntaxError(

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -261,7 +261,9 @@ def do_uni_form(parser, token):
     if template_pack is not None:
         template_pack = template_pack[1:-1]
         ALLOWED_TEMPLATE_PACKS = getattr(
-            settings, "CRISPY_ALLOWED_TEMPLATE_PACKS", ("bootstrap", "uni_form", "bootstrap3", "bootstrap4", "tailwind")
+            settings,
+            "CRISPY_ALLOWED_TEMPLATE_PACKS",
+            ("bootstrap", "uni_form", "bootstrap3", "bootstrap4", "tailwind"),
         )
         if template_pack not in ALLOWED_TEMPLATE_PACKS:
             raise template.TemplateSyntaxError(

--- a/crispy_forms/tests/conftest.py
+++ b/crispy_forms/tests/conftest.py
@@ -8,6 +8,7 @@ only_bootstrap3 = pytest.mark.only("bootstrap3")
 only_bootstrap4 = pytest.mark.only("bootstrap4")
 only_tailwind = pytest.mark.only("tailwind")
 
+
 @pytest.fixture
 def advanced_layout():
     return Layout(

--- a/crispy_forms/tests/conftest.py
+++ b/crispy_forms/tests/conftest.py
@@ -6,7 +6,7 @@ only_uni_form = pytest.mark.only("uni_form")
 only_bootstrap = pytest.mark.only("bootstrap", "bootstrap3", "bootstrap4")
 only_bootstrap3 = pytest.mark.only("bootstrap3")
 only_bootstrap4 = pytest.mark.only("bootstrap4")
-
+only_tailwind = pytest.mark.only("tailwind")
 
 @pytest.fixture
 def advanced_layout():
@@ -22,7 +22,7 @@ def advanced_layout():
     )
 
 
-@pytest.fixture(autouse=True, params=("uni_form", "bootstrap", "bootstrap3", "bootstrap4"))
+@pytest.fixture(autouse=True, params=("uni_form", "bootstrap", "bootstrap3", "bootstrap4", "tailwind"))
 def template_packs(request, settings):
     check_template_pack(request.node, request.param)
     settings.CRISPY_TEMPLATE_PACK = request.param

--- a/crispy_forms/tests/test_tailwind.py
+++ b/crispy_forms/tests/test_tailwind.py
@@ -1,24 +1,17 @@
-from crispy_forms.tailwind import CSSContainer
 from django.template import Context, Template
-from .forms import SampleForm
+
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout
-from  .conftest import only_tailwind
+from crispy_forms.tailwind import CSSContainer
 
-individual_inputs = {
-    "text": "text",
-    "radioselect": "radio"
-}
+from .conftest import only_tailwind
+from .forms import SampleForm
 
-base_standalone = {
-    "base": "base"
-}
+individual_inputs = {"text": "text", "radioselect": "radio"}
 
-combined = {
-    "base": "base",
-    "text": "text",
-    "radioselect": "radio"
-}
+base_standalone = {"base": "base"}
+
+combined = {"base": "base", "text": "text", "radioselect": "radio"}
 
 
 def test_individual_input():
@@ -54,9 +47,7 @@ def test_add_remove_extra_class():
 def test_form():
     form_helper = FormHelper()
     form_helper.css_container = CSSContainer(base_standalone)
-    form_helper.layout = Layout(
-        'first_name'
-    )
+    form_helper.layout = Layout("first_name")
 
     template = Template(
         """

--- a/crispy_forms/tests/test_tailwind.py
+++ b/crispy_forms/tests/test_tailwind.py
@@ -1,0 +1,70 @@
+from crispy_forms.tailwind import CSSContainer
+from django.template import Context, Template
+from .forms import SampleForm
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout
+from  .conftest import only_tailwind
+
+individual_inputs = {
+    "text": "text",
+    "radioselect": "radio"
+}
+
+base_standalone = {
+    "base": "base"
+}
+
+combined = {
+    "base": "base",
+    "text": "text",
+    "radioselect": "radio"
+}
+
+
+def test_individual_input():
+    container = CSSContainer(individual_inputs)
+    assert container.text == "text"
+    assert container.radioselect == "radio"
+    assert container.checkbox == ""
+
+
+def test_base_input():
+    container = CSSContainer(base_standalone)
+    for item in container.__dict__.values():
+        assert item == "base"
+
+
+def test_base_and_individual():
+    container = CSSContainer(combined)
+    assert "base" in container.text
+    assert "text" in container.text
+    assert "base" in container.radioselect
+    assert "radio" in container.radioselect
+
+
+def test_add_remove_extra_class():
+    container = CSSContainer(base_standalone)
+    container += individual_inputs
+    assert "text" in container.text
+    container -= individual_inputs
+    assert "text" not in container.text
+
+
+@only_tailwind
+def test_form():
+    form_helper = FormHelper()
+    form_helper.css_container = CSSContainer(base_standalone)
+    form_helper.layout = Layout(
+        'first_name'
+    )
+
+    template = Template(
+        """
+        {% load crispy_forms_tags %}
+        {% crispy form form_helper %}
+        """
+    )
+
+    context = Context({"form": SampleForm(), "form_helper": form_helper})
+    html = template.render(context)
+    assert "base" in html


### PR DESCRIPTION
Hi @carltongibson @bryan-brancotte 

Hope you are both well. 

Time for a bit of show and tell. 👀 

Once you've read the below I'm interested in your view on the following:

- API design - how can it be improved
- Is this idea worth progressing further (a quick google doesn't show anyone else with a template pack)
- Thoughts on next steps, how would we progress. (I think let's agree the API, and ship it. We would never spot/fix bugs unless it gets used)
- Crispy-Forms vs new package (my view is the latter, but there are options here)
- Suspect I need to go and fix a couple of the standard tests... the ones which count inputs are bound to fail....

I've had a go at trying to add support for Tailwind. Tailwind as a utlity first framework doesn't have pre-built form layouts we can copy. Further I feel that taking an opinion is against the point of it being utility first. 

I've therefore created a new class to use as a data store for the css classes. The templates then access these and add them where needed. This is the first time I've created an API like this so I'd really value any feedback. It works something like this. 

```
# pass in a dictionary with a style for each input type
style = {"text": "mb-2 text-red-600"}
css_container = CSSContainer(style)
css_container
Out[10]: {'text': 'text-red-600 mb-2', 'number': '', 'email': '', 'url': '', 'password': '', 'hidden': '', 'multiplehidden': '', 'file': '', 'clearablefile': '', 'textarea': '', 'date': '', 'datetime': '', 'time': '', 'checkbox': '', 'select': '', 'nullbooleanselect': '', 'selectmultiple': '', 'radioselect': '', 'checkboxselectmultiple': '', 'multi': '', 'splitdatetime': '', 'splithiddendatetime': '', 'selectdate': ''}
# this could get a bit long winded, so let's fast track and add a base style to all input types
base_style = {"base": "apply to all"}
css_container = CSSContainer(base_style)
css_container
Out[13]: {'text': 'apply to all', 'number': 'apply to all', 'email': 'apply to all', 'url': 'apply to all', 'password': 'apply to all', 'hidden': 'apply to all', 'multiplehidden': 'apply to all', 'file': 'apply to all', 'clearablefile': 'apply to all', 'textarea': 'apply to all', 'date': 'apply to all', 'datetime': 'apply to all', 'time': 'apply to all', 'checkbox': 'apply to all', 'select': 'apply to all', 'nullbooleanselect': 'apply to all', 'selectmultiple': 'apply to all', 'radioselect': 'apply to all', 'checkboxselectmultiple': 'apply to all', 'multi': 'apply to all', 'splitdatetime': 'apply to all', 'splithiddendatetime': 'apply to all', 'selectdate': 'apply to all'}
# now we can update as we go
css_container.text = ""
css_container
Out[22]: {'text': '', 'number': 'apply to all', 'email': 'apply to all', 'url': 'apply to all', 'password': 'apply to all', 'hidden': 'apply to all', 'multiplehidden': 'apply to all', 'file': 'apply to all', 'clearablefile': 'apply to all', 'textarea': 'apply to all', 'date': 'apply to all', 'datetime': 'apply to all', 'time': 'apply to all', 'checkbox': 'apply to all', 'select': 'apply to all', 'nullbooleanselect': 'apply to all', 'selectmultiple': 'apply to all', 'radioselect': 'apply to all', 'checkboxselectmultiple': 'apply to all', 'multi': 'apply to all', 'splitdatetime': 'apply to all', 'splithiddendatetime': 'apply to all', 'selectdate': 'apply to all'}
# can add and remove as well
css_container += style
css_container
Out[24]: {'text': 'text-red-600 mb-2', 'number': 'apply to all', 'email': 'apply to all', 'url': 'apply to all', 'password': 'apply to all', 'hidden': 'apply to all', 'multiplehidden': 'apply to all', 'file': 'apply to all', 'clearablefile': 'apply to all', 'textarea': 'apply to all', 'date': 'apply to all', 'datetime': 'apply to all', 'time': 'apply to all', 'checkbox': 'apply to all', 'select': 'apply to all', 'nullbooleanselect': 'apply to all', 'selectmultiple': 'apply to all', 'radioselect': 'apply to all', 'checkboxselectmultiple': 'apply to all', 'multi': 'apply to all', 'splitdatetime': 'apply to all', 'splithiddendatetime': 'apply to all', 'selectdate': 'apply to all'}
remove_style = {"text": "mb-2"}
css_container -= remove_style
css_container
Out[31]: {'text': 'text-red-600', 'number': 'apply to all', 'email': 'apply to all', 'url': 'apply to all', 'password': 'apply to all', 'hidden': 'apply to all', 'multiplehidden': 'apply to all', 'file': 'apply to all', 'clearablefile': 'apply to all', 'textarea': 'apply to all', 'date': 'apply to all', 'datetime': 'apply to all', 'time': 'apply to all', 'checkbox': 'apply to all', 'select': 'apply to all', 'nullbooleanselect': 'apply to all', 'selectmultiple': 'apply to all', 'radioselect': 'apply to all', 'checkboxselectmultiple': 'apply to all', 'multi': 'apply to all', 'splitdatetime': 'apply to all', 'splithiddendatetime': 'apply to all', 'selectdate': 'apply to all'}

```
In addition there is a "option_label" that can be passed in to style radio / checkbox input labels. Input labels are styled using existing functionality. 

I've also built out a template using crispy-test-project (although I've just realised I've broken master as it needs this PR to work, sorry.)

Here is the image. 

![screencapture-127-0-0-1-8000-tailwind-2020-04-21-20_56_13](https://user-images.githubusercontent.com/39445562/79908556-58f64100-8413-11ea-9d33-7983636a62f4.png)

Looking forward to hearing from you. 
