### PR TITLE
Build only Python 3 wheels.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [metadata]
 license-file = LICENSE.txt
 
-[bdist_wheel]
-universal=1
-
 [isort]
 multi_line_output=3
 include_trailing_comma=True


### PR DESCRIPTION
Since dropping Python 2 universal wheels are no longer needed.