### PR TITLE
Used f strings

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -196,7 +196,7 @@ class StrictButton(TemplateNameMixin):
             kwargs["id"] = kwargs.pop("css_id")
         kwargs["class"] = self.field_classes
         if "css_class" in kwargs:
-            kwargs["class"] += " %s" % kwargs.pop("css_class")
+            kwargs["class"] += f" {kwargs.pop('css_class')}"
 
         self.flat_attrs = flatatt(kwargs)
 

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -322,7 +322,7 @@ class FormHelper(DynamicLayoutHandler):
             "disable_csrf": self.disable_csrf,
             "error_text_inline": self.error_text_inline,
             "field_class": self.field_class,
-            "field_template": self.field_template or "%s/field.html" % template_pack,
+            "field_template": self.field_template or f"{template_pack}/field.html",
             "form_method": self.form_method.strip(),
             "form_show_errors": self.form_show_errors,
             "form_show_labels": self.form_show_labels,
@@ -359,7 +359,7 @@ class FormHelper(DynamicLayoutHandler):
         if self.form_class:
             # uni_form TEMPLATE PACK has a uniForm class by default
             if template_pack == "uni_form":
-                items["attrs"]["class"] = "uniForm %s" % self.form_class.strip()
+                items["attrs"]["class"] = f"uniForm {self.form_class.strip()}"
             else:
                 items["attrs"]["class"] = self.form_class.strip()
         else:

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -181,7 +181,7 @@ class BaseInput(TemplateNameMixin):
         self.attrs = {}
 
         if "css_class" in kwargs:
-            self.field_classes += " %s" % kwargs.pop("css_class")
+            self.field_classes += f" {kwargs.pop('css_class')}"
 
         self.template = kwargs.pop("template", self.template)
         self.flat_attrs = flatatt(kwargs)
@@ -290,7 +290,7 @@ class Fieldset(LayoutObject):
 
         legend = ""
         if self.legend:
-            legend = "%s" % Template(str(self.legend)).render(context)
+            legend = f"{Template(str(self.legend)).render(context)}"
 
         template = self.get_template_name(template_pack)
         return render_to_string(
@@ -355,7 +355,7 @@ class Div(LayoutObject):
         self.fields = list(fields)
 
         if hasattr(self, "css_class") and "css_class" in kwargs:
-            self.css_class += " %s" % kwargs.pop("css_class")
+            self.css_class += f" {kwargs.pop('css_class')}"
         if not hasattr(self, "css_class"):
             self.css_class = kwargs.pop("css_class", None)
 
@@ -436,7 +436,7 @@ class Field(LayoutObject):
 
         if "css_class" in kwargs:
             if "class" in self.attrs:
-                self.attrs["class"] += " %s" % kwargs.pop("css_class")
+                self.attrs["class"] += f" {kwargs.pop('css_class')}"
             else:
                 self.attrs["class"] = kwargs.pop("css_class")
 

--- a/crispy_forms/layout_slice.py
+++ b/crispy_forms/layout_slice.py
@@ -148,7 +148,7 @@ class LayoutSlice:
             if hasattr(layout_object, "attrs"):
                 if "css_class" in kwargs:
                     if "class" in layout_object.attrs:
-                        layout_object.attrs["class"] += " %s" % kwargs.pop("css_class")
+                        layout_object.attrs["class"] += f" {kwargs.pop('css_class')}"
                     else:
                         layout_object.attrs["class"] = kwargs.pop("css_class")
                 layout_object.attrs.update(kwargs)

--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -115,7 +115,7 @@ class CrispyFieldNode(template.Node):
             css_class = widget.attrs.get("class", "")
             if css_class:
                 if css_class.find(class_name) == -1:
-                    css_class += " %s" % class_name
+                    css_class += f" {class_name}"
             else:
                 css_class = class_name
 
@@ -186,7 +186,7 @@ def crispy_addon(field, append="", prepend="", form_show_labels=True):
     """
     if field:
         context = Context({"field": field, "form_show_errors": True, "form_show_labels": form_show_labels})
-        template = loader.get_template("%s/layout/prepended_appended_text.html" % get_template_pack())
+        template = loader.get_template(f"{get_template_pack()}/layout/prepended_appended_text.html")
         context["crispy_prepended_text"] = prepend
         context["crispy_appended_text"] = append
 

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -13,12 +13,12 @@ from crispy_forms.utils import TEMPLATE_PACK, flatatt
 
 @lru_cache()
 def uni_formset_template(template_pack=TEMPLATE_PACK):
-    return get_template("%s/uni_formset.html" % template_pack)
+    return get_template(f"{template_pack}/uni_formset.html")
 
 
 @lru_cache()
 def uni_form_template(template_pack=TEMPLATE_PACK):
-    return get_template("%s/uni_form.html" % template_pack)
+    return get_template(f"{template_pack}/uni_form.html")
 
 
 register = template.Library()
@@ -47,7 +47,7 @@ def as_crispy_form(form, template_pack=TEMPLATE_PACK, label_class="", field_clas
     c = Context(
         {
             "field_class": field_class,
-            "field_template": "%s/field.html" % template_pack,
+            "field_template": f"{template_pack}/field.html",
             "form_show_errors": True,
             "form_show_labels": True,
             "label_class": label_class,
@@ -76,10 +76,10 @@ def as_crispy_errors(form, template_pack=TEMPLATE_PACK):
         {{ form|as_crispy_errors:"bootstrap" }}
     """
     if isinstance(form, BaseFormSet):
-        template = get_template("%s/errors_formset.html" % template_pack)
+        template = get_template(f"{template_pack}/errors_formset.html")
         c = Context({"formset": form}).flatten()
     else:
-        template = get_template("%s/errors.html" % template_pack)
+        template = get_template(f"{template_pack}/errors.html")
         c = Context({"form": form}).flatten()
 
     return template.render(c)
@@ -114,7 +114,7 @@ def as_crispy_field(field, template_pack=TEMPLATE_PACK, label_class="", field_cl
         attributes.update(helper.get_attributes(template_pack))
         template_path = helper.field_template
     if not template_path:
-        template_path = "%s/field.html" % template_pack
+        template_path = f"{template_pack}/field.html"
     template = get_template(template_path)
 
     c = Context(attributes).flatten()

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -152,13 +152,13 @@ class BasicNode(template.Node):
 
         # We take form/formset parameters from attrs if they are set, otherwise we use defaults
         response_dict = {
-            "%s_action" % form_type: attrs["attrs"].get("action", ""),
-            "%s_attrs" % form_type: attrs.get("attrs", ""),
-            "%s_class" % form_type: attrs["attrs"].get("class", ""),
-            "%s_id" % form_type: attrs["attrs"].get("id", ""),
-            "%s_method" % form_type: attrs.get("form_method", "post"),
-            "%s_style" % form_type: attrs.get("form_style", None),
-            "%s_tag" % form_type: attrs.get("form_tag", True),
+            f"{form_type}_action": attrs["attrs"].get("action", ""),
+            f"{form_type}_attrs": attrs.get("attrs", ""),
+            f"{form_type}_class": attrs["attrs"].get("class", ""),
+            f"{form_type}_id": attrs["attrs"].get("id", ""),
+            f"{form_type}_method": attrs.get("form_method", "post"),
+            f"{form_type}_style": attrs.get("form_style", None),
+            f"{form_type}_tag": attrs.get("form_tag", True),
             "disable_csrf": attrs.get("disable_csrf", False),
             "error_text_inline": attrs.get("error_text_inline", True),
             "field_class": attrs.get("field_class", ""),
@@ -190,12 +190,12 @@ class BasicNode(template.Node):
 
 @lru_cache()
 def whole_uni_formset_template(template_pack=TEMPLATE_PACK):
-    return get_template("%s/whole_uni_formset.html" % template_pack)
+    return get_template(f"{template_pack}/whole_uni_formset.html")
 
 
 @lru_cache()
 def whole_uni_form_template(template_pack=TEMPLATE_PACK):
-    return get_template("%s/whole_uni_form.html" % template_pack)
+    return get_template(f"{template_pack}/whole_uni_form.html")
 
 
 class CrispyFormNode(BasicNode):
@@ -239,7 +239,7 @@ def do_uni_form(parser, token):
     form = token.pop(1)
 
     helper = None
-    template_pack = "'%s'" % get_template_pack()
+    template_pack = f"'{get_template_pack()}'"
 
     # {% crispy form helper %}
     try:
@@ -265,7 +265,7 @@ def do_uni_form(parser, token):
         )
         if template_pack not in ALLOWED_TEMPLATE_PACKS:
             raise template.TemplateSyntaxError(
-                "crispy tag's template_pack argument should be in %s" % str(ALLOWED_TEMPLATE_PACKS)
+                f"crispy tag's template_pack argument should be in {str(ALLOWED_TEMPLATE_PACKS)}"
             )
 
     return CrispyFormNode(form, helper, template_pack=template_pack)

--- a/crispy_forms/tests/conftest.py
+++ b/crispy_forms/tests/conftest.py
@@ -32,4 +32,4 @@ def check_template_pack(node, template_pack):
     mark = node.get_closest_marker("only")
     if mark:
         if template_pack not in mark.args:
-            pytest.skip("Requires %s template pack" % " or ".join(mark.args))
+            pytest.skip(f"Requires {' or '.join(mark.args)} template pack")

--- a/crispy_forms/tests/test_form_helper.py
+++ b/crispy_forms/tests/test_form_helper.py
@@ -89,7 +89,7 @@ def test_form_with_helper_without_layout(settings):
     assert "forms-that-rock" in html
     assert 'method="get"' in html
     assert 'id="this-form-rocks"' in html
-    assert 'action="%s"' % reverse("simpleAction") in html
+    assert f"action=\"{reverse('simpleAction')}\"" in html
 
     if settings.CRISPY_TEMPLATE_PACK == "uni_form":
         assert 'class="uniForm' in html
@@ -401,7 +401,7 @@ def test_formset_with_helper_without_layout(settings):
     assert "formsets-that-rock" in html
     assert 'method="post"' in html
     assert 'id="thisFormsetRocks"' in html
-    assert 'action="%s"' % reverse("simpleAction") in html
+    assert f"action=\"{reverse('simpleAction')}\"" in html
     if settings.CRISPY_TEMPLATE_PACK == "uni_form":
         assert 'class="uniForm' in html
 
@@ -553,7 +553,7 @@ def test_helper_custom_field_template_no_layout():
 
     html = render_crispy_form(form)
     for field in form.fields:
-        assert html.count('id="div_id_%s"' % field) == 1
+        assert html.count(f'id="div_id_{field}"') == 1
     assert html.count("<h1>Special custom field</h1>") == len(form.fields)
 
 
@@ -563,7 +563,7 @@ def test_helper_std_field_template_no_layout():
 
     html = render_crispy_form(form)
     for field in form.fields:
-        assert html.count('id="div_id_%s"' % field) == 1
+        assert html.count(f'id="div_id_{field}"') == 1
 
 
 @only_uni_form

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -306,7 +306,7 @@ def test_formset_layout(settings):
     assert "formsets-that-rock" in html
     assert 'method="post"' in html
     assert 'id="thisFormsetRocks"' in html
-    assert 'action="%s"' % reverse("simpleAction") in html
+    assert f"action=\"{reverse('simpleAction')}\"" in html
 
     # Check form layout
     assert "Item 1" in html

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -278,7 +278,7 @@ class TestBootstrapLayoutObjects:
         elif settings.CRISPY_TEMPLATE_PACK == "bootstrap4":
             accordion_class = "collapse show"
 
-        assert html.count('<div id="one" class="%s"' % accordion_class) == 1
+        assert html.count(f'<div id="one" class="{accordion_class}"') == 1
 
         test_form.helper.layout = Layout(
             Accordion(AccordionGroup("one", "first_name", active=False,),)  # now ``active`` manually set as False
@@ -286,7 +286,7 @@ class TestBootstrapLayoutObjects:
 
         # This time, it shouldn't be there at all.
         html = render_crispy_form(test_form)
-        assert html.count('<div id="one" class="%s collapse in"' % accordion_class) == 0
+        assert html.count(f'<div id="one" class="{accordion_class} collapse in"') == 0
 
     def test_alert(self):
         test_form = SampleForm()
@@ -375,9 +375,9 @@ class TestBootstrapLayoutObjects:
         # else:
         # tab_class = 'tab-pane'
         # tab 1 should not be active
-        assert html.count('<div id="one" \n    class="{} active'.format(tab_class)) == 0
+        assert html.count(f'<div id="one" \n    class="{tab_class} active') == 0
         # tab 2 should be active
-        assert html.count('<div id="two" \n    class="{} active'.format(tab_class)) == 1
+        assert html.count(f'<div id="two" \n    class="{tab_class} active') == 1
 
     def test_radio_attrs(self):
         form = CheckboxesSampleForm()
@@ -406,7 +406,7 @@ class TestBootstrapLayoutObjects:
         if settings.CRISPY_TEMPLATE_PACK in ("bootstrap3", "bootstrap4"):
             form_group_class = "form-group"
 
-        assert html.count('class="%s extra"' % form_group_class) == 1
+        assert html.count(f'class="{form_group_class} extra"') == 1
         assert html.count('autocomplete="off"') == 1
         assert html.count('class="span4') == 1
         assert html.count('id="go-button"') == 1
@@ -480,5 +480,5 @@ class TestBootstrapLayoutObjects:
             "numeric_multiple_checkboxes_3",
         ]
         for id_suffix in expected_ids:
-            expected_str = 'id="id_{id_suffix}"'.format(id_suffix=id_suffix)
+            expected_str = f'id="id_{id_suffix}"'
             assert html.count(expected_str) == 1

--- a/crispy_forms/tests/utils.py
+++ b/crispy_forms/tests/utils.py
@@ -11,7 +11,7 @@ def contains_partial(haystack, needle, ignore_needle_children=False):
         needle = parse_html(needle)
 
     if len(needle.children) > 0 and not ignore_needle_children:
-        raise NotImplementedError("contains_partial does not check needle's children:%s" % str(needle.children))
+        raise NotImplementedError(f"contains_partial does not check needle's children:{str(needle.children)}")
 
     if needle.name == haystack.name and set(needle.attributes).issubset(haystack.attributes):
         return True

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -22,7 +22,7 @@ TEMPLATE_PACK = SimpleLazyObject(get_template_pack)
 # is called without a template
 @lru_cache()
 def default_field_template(template_pack=TEMPLATE_PACK):
-    return get_template("%s/field.html" % template_pack)
+    return get_template(f"{template_pack}/field.html")
 
 
 def render_field(  # noqa: C901
@@ -93,19 +93,19 @@ def render_field(  # noqa: C901
 
         except KeyError:
             if not FAIL_SILENTLY:
-                raise Exception("Could not resolve form field '%s'." % field)
+                raise Exception(f"Could not resolve form field '{field}'.")
             else:
                 field_instance = None
-                logging.warning("Could not resolve form field '%s'." % field, exc_info=sys.exc_info())
+                logging.warning(f"Could not resolve form field '{field}'.", exc_info=sys.exc_info())
 
         if hasattr(form, "rendered_fields"):
             if field not in form.rendered_fields:
                 form.rendered_fields.add(field)
             else:
                 if not FAIL_SILENTLY:
-                    raise Exception("A field should only be rendered once: %s" % field)
+                    raise Exception(f"A field should only be rendered once: {field}")
                 else:
-                    logging.warning("A field should only be rendered once: %s" % field, exc_info=sys.exc_info())
+                    logging.warning(f"A field should only be rendered once: {field}", exc_info=sys.exc_info())
 
         if field_instance is None:
             html = ""


### PR DESCRIPTION
Ran `flynt` on the entire code base to translate string formats into f string style.

@carltongibson I'm confused on the support policy for Django. Hope you can help 😄 

Django 2.2 is LTS so will be supported for some time, yet Python 3.5 is EOL September of this year. Therefore do we need to support Python 3.5 until September or until Django 2.2 is EOL?

Thanks!

p.s.
This _should_ fail on Python 3.5.....