### PR TITLE
Changed urlpatterns to use path

### DIFF
--- a/crispy_forms/tests/urls.py
+++ b/crispy_forms/tests/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url
+from django.urls import path
 from django.views.generic import View
 
 urlpatterns = [
-    url(r"^simple/action/$", View.as_view(), name="simpleAction"),
+    path("simple/action/", View.as_view(), name="simpleAction"),
 ]


### PR DESCRIPTION
url() is deprecated in Django4.0