### PR TITLE
Django 3.1 requires version 1.9 or higher

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ django-crispy-forms
 
 The best way to have Django_ DRY forms. Build programmatic reusable layouts out of components, having full control of the rendered HTML without writing HTML in templates. All this without breaking the standard way of doing things in Django, so it plays nice with any other form application.
 
-`django-crispy-forms` supports Django 2.2 and 3.0 with Python 3.5+.
+`django-crispy-forms` supports Django 2.2, 3.0 and 3.1 with Python 3.5+. **Note: Django 3.1 requires `django-crispy-forms` version 1.9 or higher**.
 
 Versions of `django-crispy-forms` prior to 1.9.0 also supported Python 2.7 and Django 1.11/2.1
 


### PR DESCRIPTION
@carltongibson @bryan-brancotte 

Django 3.1 is coming 🎉 

However, `crispy-forms` version 1.9+ is required to work with Django 3.1. To try and communicate this I've added a note to the readme. Is this enough?

Appreciate thoughts. 


