### PR TITLE
Make flake8 fail loudly

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -17,18 +17,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-#    - name: Install dependencies
-#      run: |
-#        python -m pip install --upgrade pip
-#        pip install -r requirements.txt
     - name: Lint with flake8
       run: |
         pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings.
-        flake8 . --exit-zero
-#    - name: Test with pytest
-#      run: |
-#        pip install pytest
-#        pytest
+        flake8 .


### PR DESCRIPTION
Flake8 github action is currently failing silently. 

If I remember correctly this was so we could get it working and then go and fix and errors. Now that we have it working let's make it fail loudly. 

This SHOULD fail as the new version of flake8 raises an error see #1052.

Once that is merged, we can re-run the checks on this PR and it should then pass. 
