### PR TITLE
Added reference to other support channels in issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,16 @@
+Hi! Thank you for using `crispy-forms`, we hope you enjoy using it as much as we do.
+
+If you have a support query we recommend using one of the support channels
+below. These have a far wider audience and so you are likely to receive a better
+and quicker response than opening an issue here.
+
+1) [The Django Forum](https://forum.djangoproject.com/)
+2) [Stack Overflow](https://stackoverflow.com/)
+3) [Django Users Mailing List](https://groups.google.com/g/django-users)
+
+If you have found a bug then please do open an issue. Please provide as much
+information as possible.
+
 * Package version:
 * Django version:
 * Python version:
@@ -13,3 +26,4 @@
 - [ ] Screenshots
 - [ ] Actual HTML generated
 - [ ] Expected HTML
+- [ ] Pull request with failing test


### PR DESCRIPTION
I've been thinking about this for a while. We get a low number of issues here that are support queries. There are far better options available than asking here. 

- Would this help?
- Anywhere else to point folk?
- What about the ordering of the items I've suggested below? 




