### PR TITLE
Split Development requirements into separate file

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pre-commit
+twine
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 coverage
-twine
-wheel
 pytest
 pytest-cov
 pytest-django
-pre-commit


### PR DESCRIPTION
We don't need to install all of the requirements to run the test suite?

Let's see what impact it has on the test run times. 