### PR TITLE
Avoid invalid Python in documentation

### DIFF
--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -288,7 +288,7 @@ These ones live under module ``crispy_forms.bootstrap``.
 
 - **Alert**: ``Alert`` generates markup in the form of an alert dialog::
 
-    Alert(content='<strong>Warning!</strong> Best check yo self, you're not looking too good.')
+    Alert(content="<strong>Warning!</strong> Best check yo self, you're not looking too good.")
 
 .. image:: images/alert.png
    :align: center


### PR DESCRIPTION
Breaks syntax highlighting, see https://django-crispy-forms.readthedocs.io/en/latest/layouts.html#bootstrap-layout-objects (scroll to the `Alert` section).