### PR TITLE
Fix `data-parent` in the AccordionGroup to refer to the Accordion id

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -342,13 +342,19 @@ class Accordion(ContainerHolder):
 
     template = "%s/accordion.html"
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
-        content = ""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-        # accordion group needs the parent div id to set `data-parent` (I don't
-        # know why). This needs to be a unique id
+        # Accordion needs to have a unique id
         if not self.css_id:
             self.css_id = "-".join(["accordion", str(randint(1000, 9999))])
+
+        # AccordionGroup need to have 'data-parent="#Accordion.id"'
+        for accordion_group in args:
+            accordion_group.data_parent = self.css_id
+
+    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
+        content = ""
 
         # Open the group that should be open.
         self.open_target_group_for_form(form)

--- a/crispy_forms/templates/bootstrap4/accordion-group.html
+++ b/crispy_forms/templates/bootstrap4/accordion-group.html
@@ -9,7 +9,7 @@
     </div>
 
     <div id="{{ div.css_id }}" class="collapse{% if div.active %} show{% endif %}" role="tabpanel"
-         aria-labelledby="{{ div.css_id }}" data-parent="#accordion">
+         aria-labelledby="{{ div.css_id }}" data-parent="#{{ div.data_parent }}">
         <div class="card-body">
             {{ fields|safe }}
         </div>

--- a/crispy_forms/templates/bootstrap4/accordion.html
+++ b/crispy_forms/templates/bootstrap4/accordion.html
@@ -1,3 +1,3 @@
-<div id="accordion" role="tablist">
+<div id="{{ accordion.css_id }}" role="tablist">
     {{ content|safe }}
 </div>

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -266,7 +266,7 @@ class TestBootstrapLayoutObjects:
             assert html.count('<div class="card mb-2"') == 2
             assert html.count('<div class="card-header"') == 2
 
-            assert html.count(f'data-parent="#{accordion_id}"') == 2
+            assert html.count('data-parent="#{}"'.format(accordion_id)) == 2
 
         assert html.count('<div id="one"') == 1
         assert html.count('<div id="two"') == 1

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -1,3 +1,5 @@
+import re
+
 from django import forms
 from django.template import Context, Template
 from django.test.html import parse_html
@@ -256,9 +258,15 @@ class TestBootstrapLayoutObjects:
             assert html.count('<div class="panel-group"') == 1
             assert html.count('<div class="panel-heading">') == 2
         elif settings.CRISPY_TEMPLATE_PACK == "bootstrap4":
-            assert html.count('<div id="accordion"') == 1
+            match = re.search('div id="(accordion-\\d+)"', html)
+            assert match
+
+            accordion_id = match.group(1)
+
             assert html.count('<div class="card mb-2"') == 2
             assert html.count('<div class="card-header"') == 2
+
+            assert html.count(f'data-parent="#{accordion_id}"') == 2
 
         assert html.count('<div id="one"') == 1
         assert html.count('<div id="two"') == 1


### PR DESCRIPTION
The Accordion unique ID is generated on the constructor of
Accordion and passed to its AccordionGroup.