### PR TITLE
Updated Python Version Matrix for Django Master

### DIFF
--- a/.github/workflows/ci-testing-django-master.yml
+++ b/.github/workflows/ci-testing-django-master.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Django master branch no longer supports Python 3.6 and 3.7.