### PR TITLE
Fixed input group size in Bootstrap 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for django-crispy-forms
 
+## Next Release (TBC)
+* Introduced new `input_size` argument to `AppendedText`, `PrependedText` and `PrependedAppendedText`. This allows
+  the size of these grouped inputs to be changed in the Bootstrap 4 template pack. (#1114)
+
 ## 1.11.2 (2021-03-16)
 * Added HTML parsing tools to help testing of template packs (#1128)
 * Fixed rendering of all widget attributes for file fields (#1130)

--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -11,15 +11,17 @@ from .utils import TEMPLATE_PACK, flatatt, render_field
 class PrependedAppendedText(Field):
     template = "%s/layout/prepended_appended_text.html"
 
-    def __init__(self, field, prepended_text=None, appended_text=None, *args, **kwargs):
+    def __init__(self, field, prepended_text=None, appended_text=None, input_size=None,*args, **kwargs):
         self.field = field
         self.appended_text = appended_text
         self.prepended_text = prepended_text
         if "active" in kwargs:
             self.active = kwargs.pop("active")
 
-        self.input_size = None
+        self.input_size = input_size
         css_class = kwargs.get("css_class", "")
+
+        # Bootstrap 3
         if "input-lg" in css_class:
             self.input_size = "input-lg"
         if "input-sm" in css_class:

--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -11,7 +11,7 @@ from .utils import TEMPLATE_PACK, flatatt, render_field
 class PrependedAppendedText(Field):
     template = "%s/layout/prepended_appended_text.html"
 
-    def __init__(self, field, prepended_text=None, appended_text=None, input_size=None,*args, **kwargs):
+    def __init__(self, field, prepended_text=None, appended_text=None, input_size=None, *args, **kwargs):
         self.field = field
         self.appended_text = appended_text
         self.prepended_text = prepended_text

--- a/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
@@ -12,9 +12,9 @@
         {% endif %}
 
         <div class="{{ field_class }}">
-            <div class="input-group">
+            <div class="input-group{% if input_size %} {{ input_size }}{% endif %}">
                 {% if crispy_prepended_text %}
-                  <div class="input-group-prepend{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">
+                  <div class="input-group-prepend{% if active %} active{% endif %}">
                     <span class="input-group-text">{{ crispy_prepended_text|safe }}</span>
                   </div>
                 {% endif %}
@@ -24,7 +24,7 @@
                     {% crispy_field field %}
                 {% endif %}
                 {% if crispy_appended_text %}
-                  <div class="input-group-append{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">
+                  <div class="input-group-append{% if active %} active{% endif %}">
                     <span class="input-group-text">{{ crispy_appended_text|safe }}</span>
                   </div>
                 {% endif %}

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -5,6 +5,7 @@ from django.template import Context, Template
 from django.test.html import parse_html
 from django.utils.translation import activate, deactivate
 from django.utils.translation import gettext as _
+from .conftest import only_bootstrap4
 
 from crispy_forms.bootstrap import (
     Accordion,
@@ -240,6 +241,19 @@ class TestBootstrapLayoutObjects:
 
         assert html.count("custom-select") == 1
         assert html.count("USD") == 1
+
+    @only_bootstrap4
+    def test_prepended_appended_text_input_size(self, settings):
+        test_form = SampleForm()
+        test_form.helper = FormHelper()
+        test_form.helper.layout = Layout(
+            PrependedAppendedText("email", "@", "gmail.com", input_size="input-group-lg"),
+            AppendedText("password1", "#", input_size="input-group-sm"),
+            PrependedText("password2", "$", input_size="input-group-lg"),
+        )
+        html = render_crispy_form(test_form)
+        assert html.count('<div class="input-group input-group-lg">') == 2
+        assert html.count('<div class="input-group input-group-sm">') == 1
 
     def test_inline_radios(self, settings):
         test_form = CheckboxesSampleForm()

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -5,7 +5,6 @@ from django.template import Context, Template
 from django.test.html import parse_html
 from django.utils.translation import activate, deactivate
 from django.utils.translation import gettext as _
-from .conftest import only_bootstrap4
 
 from crispy_forms.bootstrap import (
     Accordion,

--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -205,7 +205,7 @@ These ones live under module ``crispy_forms.bootstrap``.
 .. image:: images/form_actions.png
    :align: center
 
-- **AppendedText**: It renders a bootstrap appended text input. The first parameter is the name of the field to add appended text to, then the appended text which can be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render appended text active::
+- **AppendedText**: It renders a bootstrap appended text input. The first parameter is the name of the field to add appended text to, then the appended text which can be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render appended text active. Accepts the `input_size`_ argument::
 
     AppendedText('field_name', 'appended text to show')
     AppendedText('field_name', '$', active=True)
@@ -213,7 +213,7 @@ These ones live under module ``crispy_forms.bootstrap``.
 .. image:: images/appended_text.png
    :align: center
 
-- **PrependedText**: It renders a bootstrap prepended text input. The first parameter is the name of the field to add prepended text to, then the prepended text which can be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render prepended text active::
+- **PrependedText**: It renders a bootstrap prepended text input. The first parameter is the name of the field to add prepended text to, then the prepended text which can be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render prepended text active. Accepts the `input_size`_ argument::
 
     PrependedText('field_name', '<b>Prepended text</b> to show')
     PrependedText('field_name', '@', placeholder="username")
@@ -221,7 +221,7 @@ These ones live under module ``crispy_forms.bootstrap``.
 .. image:: images/prepended_text.png
    :align: center
 
-- **PrependedAppendedText**: It renders a combined prepended and appended text. The first parameter is the name of the field, then the prepended text and finally the appended text::
+- **PrependedAppendedText**: It renders a combined prepended and appended text. The first parameter is the name of the field, then the prepended text and finally the appended text. Accepts the `input_size`_ argument::
 
     PrependedAppendedText('field_name', '$', '.00'),
 
@@ -257,7 +257,17 @@ These ones live under module ``crispy_forms.bootstrap``.
 .. image:: images/field_with_buttons.png
    :align: center
 
-- **Tab & TabHolder**: ``Tab`` renders a tab, different tabs need to be wrapped in a ``TabHolder`` for automatic JavasSript functioning, also you will need ``bootstrap-tab.js`` included in your static files::
+- **Input group size**: Adjust the size of an input group (``FieldWithButton``, ``AppendedText``, ``PrependedText``, ``PrependedAppendedText``) with the appropriate CSS class, e.g.::
+
+    # Bootstrap 3
+    FieldWithButton('field_name', StrictButton("Go!"), input_size="input-sm")
+    FieldWithButton('field_name', StrictButton("Go!"), input_size="input-lg")
+
+    # Bootstrap 4
+    FieldWithButton('field_name', StrictButton("Go!"), input_size="input-group-sm")
+    FieldWithButton('field_name', StrictButton("Go!"), input_size="input-group-lg")
+
+- **Tab & TabHolder**: ``Tab`` renders a tab, different tabs need to be wrapped in a ``TabHolder`` for automatic javascript functioning, also you will need ``bootstrap-tab.js`` included in your static files::
 
     TabHolder(
         Tab('First Tab',
@@ -300,6 +310,21 @@ These ones live under module ``crispy_forms.bootstrap``.
 
 .. image:: images/field_disabled.png
    :align: center
+
+.. _`input_size`:
+
+Input group size
+----------------
+
+**Input group size**: Adjust the size of an input group (``AppendedText``, ``PrependedText``, ``PrependedAppendedText``) with the appropriate CSS class::
+
+    # Bootstrap 3 - Inputs and spans need size class. Use `css_class`.
+    PrependedText('field_name', StrictButton("Go!"), css_class="input-sm")
+    PrependedText('field_name', StrictButton("Go!"), css_class="input-lg")
+
+    # Bootstrap 4 - Wrapping div needs size class. Use `input_size`.
+    PrependedText('field_name', StrictButton("Go!"), input_size="input-group-sm")
+    PrependedText('field_name', StrictButton("Go!"), input_size="input-group-lg")
 
 .. _`override templates`:
 

--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -257,7 +257,7 @@ These ones live under module ``crispy_forms.bootstrap``.
 .. image:: images/field_with_buttons.png
    :align: center
 
-- **Tab & TabHolder**: ``Tab`` renders a tab, different tabs need to be wrapped in a ``TabHolder`` for automatic javascript functioning, also you will need ``bootstrap-tab.js`` included in your static files::
+- **Tab & TabHolder**: ``Tab`` renders a tab, different tabs need to be wrapped in a ``TabHolder`` for automatic JavaScript functioning, also you will need ``bootstrap-tab.js`` included in your static files::
 
     TabHolder(
         Tab('First Tab',
@@ -306,7 +306,7 @@ These ones live under module ``crispy_forms.bootstrap``.
 Input group size
 ----------------
 
-**Input group size**: Adjust the size of an input group (``AppendedText``, ``PrependedText``, ``PrependedAppendedText``) with the appropriate CSS class::
+**Input group size**: By default the standard Bootstrap input sizes are used. To adjust the size of an input group (``AppendedText``, ``PrependedText``, ``PrependedAppendedText``) add the appropriate CSS class::
 
     # Bootstrap 3 - Inputs and spans need size class. Use `css_class`.
     PrependedText('field_name', StrictButton("Go!"), css_class="input-sm")

--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -205,7 +205,7 @@ These ones live under module ``crispy_forms.bootstrap``.
 .. image:: images/form_actions.png
    :align: center
 
-- **AppendedText**: It renders a bootstrap appended text input. The first parameter is the name of the field to add appended text to, then the appended text which can be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render appended text active. Accepts the `input_size`_ argument::
+- **AppendedText**: It renders a bootstrap appended text input. The first parameter is the name of the field to add appended text to, then the appended text which can be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render appended text active. See `input_size`_ to change the size of this input::
 
     AppendedText('field_name', 'appended text to show')
     AppendedText('field_name', '$', active=True)
@@ -213,7 +213,7 @@ These ones live under module ``crispy_forms.bootstrap``.
 .. image:: images/appended_text.png
    :align: center
 
-- **PrependedText**: It renders a bootstrap prepended text input. The first parameter is the name of the field to add prepended text to, then the prepended text which can be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render prepended text active. Accepts the `input_size`_ argument::
+- **PrependedText**: It renders a bootstrap prepended text input. The first parameter is the name of the field to add prepended text to, then the prepended text which can be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render prepended text active. See `input_size`_ to change the size of this input::
 
     PrependedText('field_name', '<b>Prepended text</b> to show')
     PrependedText('field_name', '@', placeholder="username")
@@ -221,7 +221,7 @@ These ones live under module ``crispy_forms.bootstrap``.
 .. image:: images/prepended_text.png
    :align: center
 
-- **PrependedAppendedText**: It renders a combined prepended and appended text. The first parameter is the name of the field, then the prepended text and finally the appended text. Accepts the `input_size`_ argument::
+- **PrependedAppendedText**: It renders a combined prepended and appended text. The first parameter is the name of the field, then the prepended text and finally the appended text. See `input_size`_ to change the size of this input::
 
     PrependedAppendedText('field_name', '$', '.00'),
 
@@ -256,16 +256,6 @@ These ones live under module ``crispy_forms.bootstrap``.
 
 .. image:: images/field_with_buttons.png
    :align: center
-
-- **Input group size**: Adjust the size of an input group (``FieldWithButton``, ``AppendedText``, ``PrependedText``, ``PrependedAppendedText``) with the appropriate CSS class, e.g.::
-
-    # Bootstrap 3
-    FieldWithButton('field_name', StrictButton("Go!"), input_size="input-sm")
-    FieldWithButton('field_name', StrictButton("Go!"), input_size="input-lg")
-
-    # Bootstrap 4
-    FieldWithButton('field_name', StrictButton("Go!"), input_size="input-group-sm")
-    FieldWithButton('field_name', StrictButton("Go!"), input_size="input-group-lg")
 
 - **Tab & TabHolder**: ``Tab`` renders a tab, different tabs need to be wrapped in a ``TabHolder`` for automatic javascript functioning, also you will need ``bootstrap-tab.js`` included in your static files::
 


### PR DESCRIPTION
@cpina this is still WIP, but thought it worth sharing more publicly my progress with this. Notes:

- I think your solution for the button groups by adding an extra argument of `input_size` is spot on. I think we need this for the append inputs as well
- This is due to bs3 and 4 having different behavior. On bs3 we want the spans and input to have a class, for bs4 we want the wrapping div to have the class (and only the wrapping div). 
- Adding this additional argument allows us to manage this flexibility -- I think we'll also need this for the bs5 pack, so will make things easier there.
- `Field_with_buttons` I've not really looked at. Tempted to chop it from this PR and get the rest of it merged.
