### PR TITLE
Fixed custom-select missing in select fields that have use_custom_con…

### DIFF
--- a/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
@@ -18,7 +18,11 @@
                     <span class="input-group-text">{{ crispy_prepended_text|safe }}</span>
                   </div>
                 {% endif %}
-                {% crispy_field field %}
+                {% if field|is_select and use_custom_control %}
+                    {% crispy_field field 'class' 'custom-select' %}
+                {% else %}
+                    {% crispy_field field %}
+                {% endif %}
                 {% if crispy_appended_text %}
                   <div class="input-group-append{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">
                     <span class="input-group-text">{{ crispy_appended_text|safe }}</span>

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -25,7 +25,7 @@ from crispy_forms.layout import HTML, Field, Layout, MultiWidgetField
 from crispy_forms.tests.utils import contains_partial
 from crispy_forms.utils import render_crispy_form
 
-from .conftest import only_bootstrap
+from .conftest import only_bootstrap, only_bootstrap4
 from .forms import CheckboxesSampleForm, SampleForm
 
 
@@ -224,6 +224,22 @@ class TestBootstrapLayoutObjects:
 
             assert 'class="form-control-lg' in html
             assert contains_partial(html, '<span class="input-group-text"/>')
+
+    @only_bootstrap4
+    def test_prepended_appended_text_in_select(self, settings):
+        test_form = SampleForm()
+        test_form.fields["select"] = forms.ChoiceField(
+            label="Select field", choices=[(1, "Choice 1"), (2, "Choice 2")]
+        )
+
+        test_form.helper = FormHelper()
+        test_form.helper.layout = Layout(
+            AppendedText("select", "USD"),
+        )
+        html = render_crispy_form(test_form)
+
+        assert html.count("custom-select") == 1
+        assert html.count("USD") == 1
 
     def test_inline_radios(self, settings):
         test_form = CheckboxesSampleForm()


### PR DESCRIPTION
…trol and prepended/appended text ((#1111)

closing #1111 