### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
-  -   repo: https://github.com/timothycrosley/isort
-      rev: 5.6.4
+  -   repo: https://github.com/pycqa/isort
+      rev: 5.7.0
       hooks:
       - id: isort
   -   repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
isort repo is now resides under the pycqa org