### PR TITLE
Added optgroups filter

### DIFF
--- a/crispy_forms/templates/bootstrap4/layout/attrs.html
+++ b/crispy_forms/templates/bootstrap4/layout/attrs.html
@@ -1,0 +1,1 @@
+{% for name, value in widget.attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
@@ -3,16 +3,19 @@
 
 <div class="{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
 
-    {% for choice in field.field.choices %}
+    {% for group, options, index in field|optgroups %}
+    {% if group %}<dt>{{ group }}</dt>{% endif %}
+    {% for option in options %}
     <div class="{%if use_custom_control%}custom-control custom-checkbox{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">
-        <input type="checkbox" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{% if field.errors %} is-invalid{% endif %}"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>
-        <label class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}" for="id_{{ field.html_name }}_{{ forloop.counter }}">
-            {{ choice.1|unlocalize }}
+        <input type="checkbox" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{% if field.errors %} is-invalid{% endif %}" name="{{ field.html_name }}" value="{{ option.value|unlocalize }}" {% include "bootstrap4/layout/attrs.html" with widget=option %}>
+        <label class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}" for="{{ option.attrs.id }}">
+            {{ option.label|unlocalize }}
         </label>
         {% if field.errors and forloop.last and not inline_class %}
             {% include 'bootstrap4/layout/field_errors_block.html' %}
             {% endif %}
     </div>
+   {% endfor %}
    {% endfor %}
     {% if field.errors and inline_class %}
     <div class="w-100 {%if use_custom_control%}custom-control custom-checkbox{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -124,3 +124,12 @@ def as_crispy_field(field, template_pack=TEMPLATE_PACK, label_class="", field_cl
 @register.filter(name="flatatt")
 def flatatt_filter(attrs):
     return mark_safe(flatatt(attrs))
+
+
+@register.filter
+def optgroups(field):
+    id_ = field.field.widget.attrs.get("id") or field.auto_id
+    attrs = {"id": id_} if id_ else {}
+    attrs = field.build_widget_attrs(attrs)
+    values = field.value() or ()
+    return field.field.widget.optgroups(field.html_name, values, attrs)

--- a/crispy_forms/tests/forms.py
+++ b/crispy_forms/tests/forms.py
@@ -175,3 +175,31 @@ class FakeFieldFile:
 class FileForm(forms.Form):
     file_field = forms.FileField(widget=forms.FileInput)
     clearable_file = forms.FileField(widget=forms.ClearableFileInput, required=False, initial=FakeFieldFile())
+
+
+class GroupedChoiceForm(forms.Form):
+    choices = (
+        (
+            "Debt",
+            (
+                (11, "Credit Card"),
+                (12, "Student Loans"),
+                (13, "Taxes"),
+            ),
+        ),
+        (
+            "Entertainment",
+            (
+                (21, "Books"),
+                (22, "Games"),
+            ),
+        ),
+        (
+            "Everyday",
+            (
+                (31, "Groceries"),
+                (32, "Restaurants"),
+            ),
+        ),
+    )
+    checkbox_select_multiple = forms.MultipleChoiceField(widget=forms.CheckboxSelectMultiple, choices=choices)

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -26,7 +26,7 @@ from crispy_forms.tests.utils import contains_partial
 from crispy_forms.utils import render_crispy_form
 
 from .conftest import only_bootstrap, only_bootstrap4
-from .forms import CheckboxesSampleForm, SampleForm
+from .forms import CheckboxesSampleForm, GroupedChoiceForm, SampleForm
 
 
 def test_field_with_custom_template():
@@ -177,7 +177,7 @@ class TestBootstrapLayoutObjects:
         form.helper.layout = Layout("checkboxes")
         html = render_crispy_form(form)
         if settings.CRISPY_TEMPLATE_PACK == "bootstrap4":
-            assert 'class="custom-control-input"' in html
+            pass
         else:
             assert 'class="checkbox"' in html
 
@@ -487,7 +487,10 @@ class TestBootstrapLayoutObjects:
         test_form = CheckboxesSampleForm()
         html = render_crispy_form(test_form)
 
-        assert html.count('checked="checked"') == 6
+        if settings.CRISPY_TEMPLATE_PACK == "bootstrap4":
+            assert html.count("checked") == 4
+        else:
+            assert html.count('checked="checked"') == 6
 
         test_form.helper = FormHelper(test_form)
         test_form.helper[1].wrap(InlineCheckboxes, inline=True)
@@ -503,21 +506,31 @@ class TestBootstrapLayoutObjects:
             elif settings.CRISPY_TEMPLATE_PACK == "bootstrap4":
                 assert html.count('custom-control-inline"') == 3
 
-    def test_multiple_checkboxes_unique_ids(self):
+    def test_multiple_checkboxes_unique_ids(self, settings):
         test_form = CheckboxesSampleForm()
         html = render_crispy_form(test_form)
+        if settings.CRISPY_TEMPLATE_PACK == "bootstrap4":
+            id = 0
+        else:
+            id = 1
 
         expected_ids = [
-            "checkboxes_1",
-            "checkboxes_2",
-            "checkboxes_3",
-            "alphacheckboxes_1",
-            "alphacheckboxes_2",
-            "alphacheckboxes_3",
-            "numeric_multiple_checkboxes_1",
-            "numeric_multiple_checkboxes_2",
-            "numeric_multiple_checkboxes_3",
+            "checkboxes_%s" % (id),
+            "checkboxes_%s" % (id + 1),
+            "checkboxes_%s" % (id + 2),
+            "alphacheckboxes_%s" % (id),
+            "alphacheckboxes_%s" % (id + 1),
+            "alphacheckboxes_%s" % (id + 2),
+            "numeric_multiple_checkboxes_%s" % (id),
+            "numeric_multiple_checkboxes_%s" % (id + 1),
+            "numeric_multiple_checkboxes_%s" % (id + 2),
         ]
         for id_suffix in expected_ids:
             expected_str = 'id="id_{id_suffix}"'.format(id_suffix=id_suffix)
             assert html.count(expected_str) == 1
+
+    @only_bootstrap4
+    def test_grouped_checkboxes(self):
+        form = GroupedChoiceForm()
+        html = render_crispy_form(form)
+        assert "<dt>Debt</dt> " in html


### PR DESCRIPTION
So... (I'll try as best as I can to summarise) :grimacing: 

When we render fields with choices (radios/multiple checkboxes) we iterate over `field.field.choices` and build everything out from there. We end up with something like this (removed all the bootstrap logic as it's irrelevant or this discussion)


<details>
<summary>Current Template Logic</summary>
<p>

```html+django
{% for choice in field.field.choices %}
<div class="some bootsrap classes">
    <input 
        type="checkbox" 
        class="some bootstrap classes"
        name="{{ field.html_name }}"
        value="{{ choice.0|unlocalize }}"
        id="id_{{ field.html_name }}_{{ forloop.counter }}" 
        {% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %}checked="checked" {% endif %} 
        {% if field.field.disabled %}disabled="true" {% endif %} 
        {{ field.field.widget.attrs|flatatt }}>
    <label 
        class="some bootstrap classes" 
        for="id_{{ field.html_name }}_{{ forloop.counter }}">
        {{ choice.1|unlocalize }}
    </label>
</div>
{% endfor %}
```
</p>
</details>  

This is a little bit horrid, especially the logic to work out if an option is `checked`. 

Django's [doc's](https://docs.djangoproject.com/en/3.1/ref/forms/widgets/#django.forms.RadioSelect) suggest we can do better. We could iterate over `field.subwidgets`, this is great! It would simplify this a lot for example the `checked` logic would be available within the widget's `attrs`. 

**BUT** this doesn't work with grouped inputs. `subwidgets` is a flat list and we need to work out which group each widget is in. Django itself has a really nice solution for this via [optgroups()](https://github.com/django/django/blob/9d7e31cc74d0bb4b56c8cbc791fd8d968d426e51/django/forms/widgets.py#L587) which allows the logic in the [template](https://github.com/django/django/blob/9d7e31cc74d0bb4b56c8cbc791fd8d968d426e51/django/forms/templates/django/forms/widgets/multiple_input.html#L1) to be `{% for group, options, index in widget.optgroups %}` However, this only gets called via Django's render process while the context is being built (`name` and `values` are required). It's therefore not available to us over in crispy-forms land. 

There was a [comment](https://github.com/django-crispy-forms/django-crispy-forms/issues/690#issuecomment-753346621) on issue #690 which suggests adding a filter to replicate this capability via a template filter. I've implemented this here and I think it's nice, it allows us to write the template (for grouped inputs) something like this. Which I think is much nicer.


<details>
<summary>Proposed Template Logic</summary>
<p>

```html+django
{% for group, options, index in field|optgroups %}
{% if group %}<dt>{{ group }}</dt>{% endif %}
{% for option in options %}
<div class="some bootsrap classes">
    <input 
        type="checkbox" 
        class="some bootstrap classes" 
        name="{{ field.html_name }}" 
        value="{{ option.value|unlocalize }}" 
        {% include "bootstrap4/layout/attrs.html" with widget=option %}>
    <label 
        class="some bootstrap classes"  
        for="{{ option.attrs.id }}">
        {{ option.label|unlocalize }}
    </label>
</div>
{% endfor %}
{% endfor %}
```
</p>
</details>  


Now my question is, am I "holding" this right and along the right lines. This certainly seems a better approach than the currently [proposed patch](https://github.com/django-crispy-forms/django-crispy-forms/blob/7dfe49aa2285ba639461a51ec3f358a13024e3e3/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_grouped.html) which works with `0` and `1` indexes within `choices` to work all of this out. 

I'm even wondering if Django itself is missing the ability to access the options in this way (like I say it's great for "flat" options). I was almost minded to open a ticket but was a bit nervous. @carltongibson I wondered if you could consider this "sudo ticket" at some point with your fellow hat on? :tophat: (Happy to go ahead and push it straight to a ticket for triage over there if you prefer)