### PR TITLE
Used lru_cache from standard library

### DIFF
--- a/crispy_forms/compatibility.py
+++ b/crispy_forms/compatibility.py
@@ -1,6 +1,0 @@
-import django
-
-if django.VERSION < (3, 0):
-    from django.utils.lru_cache import lru_cache  # noqa: F401
-else:
-    from functools import lru_cache  # noqa: F401

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from django import template
 from django.conf import settings
 from django.forms import boundfield
@@ -6,7 +8,6 @@ from django.template import Context
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
 
-from crispy_forms.compatibility import lru_cache
 from crispy_forms.exceptions import CrispyError
 from crispy_forms.utils import TEMPLATE_PACK, flatatt
 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -1,9 +1,10 @@
+from functools import lru_cache
+
 from django import template
 from django.conf import settings
 from django.forms.formsets import BaseFormSet
 from django.template.loader import get_template
 
-from crispy_forms.compatibility import lru_cache
 from crispy_forms.helper import FormHelper
 from crispy_forms.utils import TEMPLATE_PACK, get_template_pack
 

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from functools import lru_cache
 
 from django.conf import settings
 from django.forms.utils import flatatt as _flatatt
@@ -8,7 +9,6 @@ from django.template.loader import get_template
 from django.utils.functional import SimpleLazyObject
 
 from .base import KeepContext
-from .compatibility import lru_cache
 
 
 def get_template_pack():


### PR DESCRIPTION
lru_cache is available in functools in all supported versions of Python. Therefore can remove compatibility.py