### PR TITLE
Renamed Django's dev branch to main

### DIFF
--- a/.github/workflows/ci-testing-django-master.yml
+++ b/.github/workflows/ci-testing-django-master.yml
@@ -1,4 +1,4 @@
-name: C/I testing - Django master
+name: C/I testing - Django main
 
 on: [push, pull_request]
 
@@ -21,7 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install https://github.com/django/django/archive/master.tar.gz
+        pip install https://github.com/django/django/archive/main.tar.gz
     - name: Test with pytest
       run: |
         cd /home/runner/work/django-crispy-forms/django-crispy-forms/

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 deps =
     django22: django>=2.2,<2.3
     django30: django>=3.0,<3.1
-    django-latest: https://github.com/django/django/archive/master.tar.gz
+    django-latest: https://github.com/django/django/archive/main.tar.gz
     -rrequirements.txt
 whitelist_externals = make
 commands = make test

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     django30: django>=3.0,<3.1
     django-latest: https://github.com/django/django/archive/main.tar.gz
     -rrequirements.txt
-whitelist_externals = make
+allowlist_externals = make
 commands = make test
 ignore_outcome =
     django-latest: True


### PR DESCRIPTION
While we're here we should replace `whitelist` with `allowlist` in tox.

I'll try and find time to make the change to the crispy-forms org. 
