### PR TITLE
Added html parsing tools for testing

### DIFF
--- a/crispy_forms/tests/results/utils_test.html
+++ b/crispy_forms/tests/results/utils_test.html
@@ -1,0 +1,7 @@
+<form method="post">
+    <div class="form-group">
+        <div class="custom-checkbox custom-control" id="div_id_is_company"><input
+                class="checkboxinput custom-control-input" id="id_is_company" name="is_company" type="checkbox"><label
+                class="custom-control-label" for="id_is_company">company</label></div>
+    </div>
+</form>

--- a/crispy_forms/tests/test_utils.py
+++ b/crispy_forms/tests/test_utils.py
@@ -8,6 +8,10 @@ from crispy_forms.layout import Layout
 from crispy_forms.tests.utils import contains_partial
 from crispy_forms.utils import list_difference, list_intersection, render_field
 
+from .conftest import only_bootstrap4
+from .forms import SampleForm
+from .utils import parse_expected, parse_form
+
 
 def test_list_intersection():
     assert list_intersection([1, 3], [2, 3]) == [3]
@@ -79,3 +83,11 @@ def test_contains_partial():
     c.assertRaises(NotImplementedError, contains_partial, html, needle)
     # as we do not look at the children, needle is equivalent to <div id="r"></div> which IS in html
     c.assertTrue(contains_partial(html, needle, ignore_needle_children=True))
+
+
+@only_bootstrap4
+def test_parse_expected_and_form():
+    form = SampleForm()
+    form.helper = FormHelper()
+    form.helper.layout = Layout("is_company")
+    assert parse_form(form) == parse_expected("utils_test.html")

--- a/crispy_forms/tests/utils.py
+++ b/crispy_forms/tests/utils.py
@@ -31,7 +31,7 @@ def contains_partial(haystack, needle, ignore_needle_children=False):
 
 def parse_expected(expected_file):
     test_file = Path(TEST_DIR) / "results" / expected_file
-    with open(test_file) as f:
+    with test_file.open() as f:
         return parse_html(f.read())
 
 

--- a/crispy_forms/tests/utils.py
+++ b/crispy_forms/tests/utils.py
@@ -1,4 +1,11 @@
+import os
+from pathlib import Path
+
 from django.test.html import Element, parse_html
+
+from crispy_forms.utils import render_crispy_form
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def contains_partial(haystack, needle, ignore_needle_children=False):
@@ -20,3 +27,14 @@ def contains_partial(haystack, needle, ignore_needle_children=False):
         for child in haystack.children
         if isinstance(child, Element)
     )
+
+
+def parse_expected(expected_file):
+    test_file = Path(TEST_DIR) / "results" / expected_file
+    with open(test_file) as f:
+        return parse_html(f.read())
+
+
+def parse_form(form):
+    html = render_crispy_form(form)
+    return parse_html(html)


### PR DESCRIPTION
This allows the expected html to be stored in an HTML file. Tests can then assert the layout of the whole form.

I've been using this method with the bootstrap5 template pack and have been enjoying working in this way. 
I'd like to introduce this here as I think it is helpful generally, I find that tests are more readable as you can see all of the output. It's also then easier to have a discussion about if there is an issue as you can point to the line in the html code that is in question. 

More specifically I think it will be helpful to prove the optgroup filter and upcoming changes are ok as we'll clearly be able to see the changes that happen (hopefully none :crossed_fingers: ) which I think could be missed with the current approach. 

