### PR TITLE
Fixed #1129: render all widget attributes for file fields in bootsrap4

### DIFF
--- a/crispy_forms/templates/bootstrap4/layout/field_file.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_file.html
@@ -27,7 +27,7 @@
     </div>
 {% endif %}
     <div class="form-control custom-file{% if field.errors %} is-invalid{%endif%}" style="border:0">
-        <input type="{{ widget.data.type }}" name="{{ widget.data.name }}" class="custom-file-input{% if field.errors %} is-invalid{%endif%}" {% if field.field.disabled %}disabled{% endif %} {% for name, value in field.field.widget.attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}>
+        <input type="{{ widget.data.type }}" name="{{ widget.data.name }}" class="custom-file-input{% if widget.data.attrs.class %} {{ widget.data.attrs.class }}{% endif %}{% if field.errors %} is-invalid{%endif%}"{% if field.field.disabled %} disabled{% endif %}{% for name, value in widget.data.attrs.items %}{% if value is not False and name != 'class' %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}>
         <label class="custom-file-label text-truncate" for="{{ field.id_for_label }}">---</label>
         <script type="text/javascript" id="script-{{ field.id_for_label }}">        
             document.getElementById("script-{{ field.id_for_label }}").parentNode.querySelector('.custom-file-input').onchange =  function (e){

--- a/crispy_forms/tests/forms.py
+++ b/crispy_forms/tests/forms.py
@@ -175,3 +175,10 @@ class FakeFieldFile:
 class FileForm(forms.Form):
     file_field = forms.FileField(widget=forms.FileInput)
     clearable_file = forms.FileField(widget=forms.ClearableFileInput, required=False, initial=FakeFieldFile())
+
+
+class AdvancedFileForm(forms.Form):
+    file_field = forms.FileField(widget=forms.FileInput(attrs={"class": "my-custom-class"}))
+    clearable_file = forms.FileField(
+        widget=forms.ClearableFileInput(attrs={"class": "my-custom-class"}), required=False, initial=FakeFieldFile()
+    )

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -15,6 +15,7 @@ from crispy_forms.utils import render_crispy_form
 
 from .conftest import only_bootstrap, only_bootstrap3, only_bootstrap4, only_uni_form
 from .forms import (
+    AdvancedFileForm,
     CheckboxesSampleForm,
     CrispyEmptyChoiceTestModel,
     CrispyTestModel,
@@ -685,18 +686,18 @@ def test_file_field():
     form.helper.layout = Layout("clearable_file")
     html = render_crispy_form(form)
     assert '<span class="custom-control custom-checkbox">' in html
-    assert '<input type="file" name="clearable_file" class="custom-file-input"  >' in html
+    assert '<input type="file" name="clearable_file" class="custom-file-input" id="id_clearable_file">' in html
 
     form.helper.use_custom_control = False
     html = render_crispy_form(form)
     assert '<input type="checkbox" name="clearable_file-clear" id="clearable_file-clear_id">' in html
-    assert '<input type="file" name="clearable_file" class="custom-file-input"  >' not in html
+    assert '<input type="file" name="clearable_file" class="custom-file-input" id="id_clearable_file">' not in html
 
     form.helper.use_custom_control = True
     form.helper.layout = Layout("file_field")
     html = render_crispy_form(form)
     assert '<div class="form-control custom-file"' in html
-    assert '<input type="file" name="file_field" class="custom-file-input"' in html
+    assert '<input type="file" name="file_field" class="custom-file-input" id="id_file_field"' in html
     assert '<label class="custom-file-label' in html
     assert 'for="id_file_field">---</label>' in html
 
@@ -705,3 +706,16 @@ def test_file_field():
     assert "custom-file" not in html
     assert "custom-file-input" not in html
     assert "custom-file-label" not in html
+
+
+@only_bootstrap4
+def test_file_field_with_custom_class():
+    form = AdvancedFileForm()
+    form.helper = FormHelper()
+    form.helper.layout = Layout("clearable_file")
+    html = render_crispy_form(form)
+    assert '<input type="file" name="clearable_file" class="custom-file-input my-custom-class"' in html
+
+    form.helper.layout = Layout("file_field")
+    html = render_crispy_form(form)
+    assert '<input type="file" name="file_field" class="custom-file-input my-custom-class"' in html


### PR DESCRIPTION
I've explained the issue a bit more in #1129 .
The main change is that the template now uses `widget.data.attrs` and that `widget.data.attrs.class` is explicitly rendered when it's there. Please let me know if you need more/different test coverage or different naming.