### PR TITLE
Fixed file field tests

### DIFF
--- a/crispy_forms/tests/results/bootstrap4/file_field/clearable_file_field.html
+++ b/crispy_forms/tests/results/bootstrap4/file_field/clearable_file_field.html
@@ -1,0 +1,11 @@
+<form method="post" enctype="multipart/form-data">
+    <div id="div_id_clearable_file" class="form-group"> <label for="id_clearable_file" class=""> Clearable file </label>
+        <div class=""> Currently: 
+            <a href="something">something</a>
+            <input type="checkbox" name="clearable_file-clear" id="clearable_file-clear_id">
+            <label for="clearable_file-clear_id">Clear</label>
+            <br>Change:
+            <input type="file" name="clearable_file" class="clearablefileinput form-control-file" id="id_clearable_file">
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/file_field/clearable_file_field_custom_class.html
+++ b/crispy_forms/tests/results/bootstrap4/file_field/clearable_file_field_custom_class.html
@@ -1,0 +1,35 @@
+<form method="post" enctype="multipart/form-data">
+    <div id="div_id_clearable_file" class="form-group"> <label for="id_clearable_file" class=""> Clearable file </label>
+        <div class=" mb-2">
+            <div class="input-group mb-2">
+                <div class="input-group-prepend"> 
+                    <span class="input-group-text">Currently</span> 
+                </div>
+                <div class="form-control d-flex h-auto"> 
+                    <span class="text-break" style="flex-grow:1;min-width:0"> 
+                        <a href="something">something</a> 
+                    </span> 
+                    <span class="align-self-center ml-2"> 
+                        <span class="custom-control custom-checkbox"> 
+                            <input type="checkbox" name="clearable_file-clear" id="clearable_file-clear_id" class="custom-control-input">
+                            <label class="custom-control-label mb-0" for="clearable_file-clear_id">Clear</label>
+                        </span>
+                    </span>
+                </div>
+            </div>
+            <div class="input-group mb-0">
+                <div class="input-group-prepend"> 
+                    <span class="input-group-text">Change</span> 
+                </div>
+                <div class="form-control custom-file" style="border:0">
+                    <input type="file" name="clearable_file" class="custom-file-input my-custom-class" id="id_clearable_file">
+                    <label class="custom-file-label text-truncate" for="id_clearable_file">---</label>
+                    <script type="text/javascript" id="script-id_clearable_file">
+                        document.getElementById("script-id_clearable_file").parentNode.querySelector('.custom-file-input').onchange =  function (e){                var filenames = "";                for (let i=0;i<e.target.files.length;i++){                    filenames+=(i>0?", ":"")+e.target.files[i].name;                }                e.target.parentNode.querySelector('.custom-file-label').textContent=filenames;                }
+                    </script>
+                </div>
+            </div>
+            <div class="input-group mb-0"> </div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/file_field/clearable_file_field_custom_control.html
+++ b/crispy_forms/tests/results/bootstrap4/file_field/clearable_file_field_custom_control.html
@@ -1,0 +1,35 @@
+<form method="post" enctype="multipart/form-data">
+    <div id="div_id_clearable_file" class="form-group"> <label for="id_clearable_file" class=""> Clearable file </label>
+        <div class=" mb-2">
+            <div class="input-group mb-2">
+                <div class="input-group-prepend"> 
+                    <span class="input-group-text">Currently</span> 
+                </div>
+                <div class="form-control d-flex h-auto"> 
+                    <span class="text-break" style="flex-grow:1;min-width:0"> 
+                        <a href="something">something</a> 
+                    </span> 
+                    <span class="align-self-center ml-2"> 
+                        <span class="custom-control custom-checkbox"> 
+                            <input type="checkbox" name="clearable_file-clear" id="clearable_file-clear_id" class="custom-control-input">
+                            <label class="custom-control-label mb-0" for="clearable_file-clear_id">Clear</label>
+                        </span>
+                    </span>
+                </div>
+            </div>
+            <div class="input-group mb-0">
+                <div class="input-group-prepend"> 
+                    <span class="input-group-text">Change</span> 
+                </div>
+                <div class="form-control custom-file" style="border:0">
+                    <input type="file" name="clearable_file" class="custom-file-input" id="id_clearable_file">
+                    <label class="custom-file-label text-truncate" for="id_clearable_file">---</label>
+                    <script type="text/javascript" id="script-id_clearable_file">
+                        document.getElementById("script-id_clearable_file").parentNode.querySelector('.custom-file-input').onchange =  function (e){                var filenames = "";                for (let i=0;i<e.target.files.length;i++){                    filenames+=(i>0?", ":"")+e.target.files[i].name;                }                e.target.parentNode.querySelector('.custom-file-label').textContent=filenames;                }
+                    </script>
+                </div>
+            </div>
+            <div class="input-group mb-0"> </div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/file_field/file_field.html
+++ b/crispy_forms/tests/results/bootstrap4/file_field/file_field.html
@@ -1,0 +1,10 @@
+<form method="post" enctype="multipart/form-data">
+    <div id="div_id_file_field" class="form-group"> 
+        <label for="id_file_field" class=" requiredField"> File field
+            <span class="asteriskField">*</span>
+        </label>
+        <div class=""> 
+            <input type="file" name="file_field" class="fileinput fileUpload form-control-file" required id="id_file_field"> 
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/file_field/file_field_custom_class.html
+++ b/crispy_forms/tests/results/bootstrap4/file_field/file_field_custom_class.html
@@ -1,0 +1,16 @@
+<form method="post" enctype="multipart/form-data">
+    <div id="div_id_file_field" class="form-group"> 
+        <label for="id_file_field" class=" requiredField"> File field
+            <span class="asteriskField">*</span> 
+        </label>
+        <div class=" mb-2">
+            <div class="form-control custom-file" style="border:0">
+                <input type="file" name="file_field" class="custom-file-input my-custom-class" id="id_file_field" required>
+                <label class="custom-file-label text-truncate" for="id_file_field">---</label>
+                <script type="text/javascript" id="script-id_file_field">
+                    document.getElementById("script-id_file_field").parentNode.querySelector('.custom-file-input').onchange =  function (e){                var filenames = "";                for (let i=0;i<e.target.files.length;i++){                    filenames+=(i>0?", ":"")+e.target.files[i].name;                }                e.target.parentNode.querySelector('.custom-file-label').textContent=filenames;                }                
+                </script>
+            </div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/file_field/file_field_custom_control.html
+++ b/crispy_forms/tests/results/bootstrap4/file_field/file_field_custom_control.html
@@ -1,0 +1,16 @@
+<form method="post" enctype="multipart/form-data">
+    <div id="div_id_file_field" class="form-group"> 
+        <label for="id_file_field" class=" requiredField"> File field
+            <span class="asteriskField">*</span> 
+        </label>
+        <div class=" mb-2">
+            <div class="form-control custom-file" style="border:0">
+                <input type="file" name="file_field" class="custom-file-input" id="id_file_field" required>
+                <label class="custom-file-label text-truncate" for="id_file_field">---</label>
+                <script type="text/javascript" id="script-id_file_field">
+                    document.getElementById("script-id_file_field").parentNode.querySelector('.custom-file-input').onchange =  function (e){                var filenames = "";                for (let i=0;i<e.target.files.length;i++){                    filenames+=(i>0?", ":"")+e.target.files[i].name;                }                e.target.parentNode.querySelector('.custom-file-label').textContent=filenames;                }                
+                </script>
+            </div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -27,7 +27,7 @@ from .forms import (
     SampleForm6,
     SelectSampleForm,
 )
-from .utils import contains_partial
+from .utils import contains_partial, parse_expected, parse_form
 
 
 def test_invalid_unicode_characters(settings):
@@ -684,28 +684,17 @@ def test_file_field():
     form = FileForm()
     form.helper = FormHelper()
     form.helper.layout = Layout("clearable_file")
-    html = render_crispy_form(form)
-    assert '<span class="custom-control custom-checkbox">' in html
-    assert '<input type="file" name="clearable_file" class="custom-file-input" id="id_clearable_file">' in html
+    assert parse_form(form) == parse_expected("bootstrap4/file_field/clearable_file_field_custom_control.html")
 
     form.helper.use_custom_control = False
-    html = render_crispy_form(form)
-    assert '<input type="checkbox" name="clearable_file-clear" id="clearable_file-clear_id">' in html
-    assert '<input type="file" name="clearable_file" class="custom-file-input" id="id_clearable_file">' not in html
+    assert parse_form(form) == parse_expected("bootstrap4/file_field/clearable_file_field.html")
 
     form.helper.use_custom_control = True
     form.helper.layout = Layout("file_field")
-    html = render_crispy_form(form)
-    assert '<div class="form-control custom-file"' in html
-    assert '<input type="file" name="file_field" class="custom-file-input" id="id_file_field"' in html
-    assert '<label class="custom-file-label' in html
-    assert 'for="id_file_field">---</label>' in html
+    assert parse_form(form) == parse_expected("bootstrap4/file_field/file_field_custom_control.html")
 
     form.helper.use_custom_control = False
-    html = render_crispy_form(form)
-    assert "custom-file" not in html
-    assert "custom-file-input" not in html
-    assert "custom-file-label" not in html
+    assert parse_form(form) == parse_expected("bootstrap4/file_field/file_field.html")
 
 
 @only_bootstrap4
@@ -713,9 +702,7 @@ def test_file_field_with_custom_class():
     form = AdvancedFileForm()
     form.helper = FormHelper()
     form.helper.layout = Layout("clearable_file")
-    html = render_crispy_form(form)
-    assert '<input type="file" name="clearable_file" class="custom-file-input my-custom-class"' in html
+    assert parse_form(form) == parse_expected("bootstrap4/file_field/clearable_file_field_custom_class.html")
 
     form.helper.layout = Layout("file_field")
-    html = render_crispy_form(form)
-    assert '<input type="file" name="file_field" class="custom-file-input my-custom-class"' in html
+    assert parse_form(form) == parse_expected("bootstrap4/file_field/file_field_custom_class.html")


### PR DESCRIPTION
Previous tests were failing due to `dict` being unordered on Python 3.5.

Following 7588f3df712be0ee3ae495979a97be059441a9ec the tests failed. See [logs](https://github.com/django-crispy-forms/django-crispy-forms/actions/runs/656748374). I've re-written the tests using the new parsing tool. I'm starting to really enjoy writing crispy-form tests in this way. 