### PR TITLE
Improved Optgroups tests

### DIFF
--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_in_select_false.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_in_select_false.html
@@ -1,0 +1,10 @@
+<form method="post">
+    <div class="form-group" id="div_id_select"><label class=" requiredField" for="id_select">Select<span
+                class="asteriskField">*</span></label>
+        <div class=""><select class="form-control select" id="id_select" name="select">
+                <option selected value="1">Option one</option>
+                <option value="2">Option two</option>
+                <option value="3">Option three</option>
+            </select></div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_in_select_true.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_in_select_true.html
@@ -1,0 +1,10 @@
+<form method="post">
+    <div class="form-group" id="div_id_select"><label class=" requiredField" for="id_select">Select<span
+                class="asteriskField">*</span></label>
+        <div class=""><select class="custom-select form-control select" id="id_select" name="select">
+                <option selected value="1">Option one</option>
+                <option value="2">Option two</option>
+                <option value="3">Option three</option>
+            </select></div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_false.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_false.html
@@ -1,7 +1,7 @@
 <form method="post">
     <div class="form-group" id="div_id_checkboxes"><label class=" requiredField" for="">Checkboxes<span
                 class="asteriskField">*</span></label>
-        <div class="">
+        <div>
             <div class="form-check"><input checked="checked" class="form-check-input" id="id_checkboxes_0" name="checkboxes"
                     type="checkbox" value="1"><label class="form-check-label" for="id_checkboxes_0">Option one</label>
             </div>
@@ -15,7 +15,7 @@
     </div>
     <div class="form-group" id="div_id_alphacheckboxes"><label class=" requiredField" for="">Alphacheckboxes<span
                 class="asteriskField">*</span></label>
-        <div class="">
+        <div>
             <div class="form-check form-check-inline"><input class="form-check-input" id="id_alphacheckboxes_0"
                     name="alphacheckboxes" type="checkbox" value="option_one"><label class="form-check-label"
                     for="id_alphacheckboxes_0">Option one</label></div>
@@ -29,7 +29,7 @@
     </div>
     <div class="form-group" id="div_id_numeric_multiple_checkboxes"><label class=" requiredField" for="">Numeric multiple
             checkboxes<span class="asteriskField">*</span></label>
-        <div class="">
+        <div>
             <div class="form-check"><input checked="checked" class="form-check-input" id="id_numeric_multiple_checkboxes_0"
                     name="numeric_multiple_checkboxes" type="checkbox" value="1"><label class="form-check-label"
                     for="id_numeric_multiple_checkboxes_0">Option one</label></div>

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_false.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_false.html
@@ -1,0 +1,44 @@
+<form method="post">
+    <div class="form-group" id="div_id_checkboxes"><label class=" requiredField" for="">Checkboxes<span
+                class="asteriskField">*</span></label>
+        <div class="">
+            <div class="form-check"><input checked="checked" class="form-check-input" id="id_checkboxes_0" name="checkboxes"
+                    type="checkbox" value="1"><label class="form-check-label" for="id_checkboxes_0">Option one</label>
+            </div>
+            <div class="form-check"><input class="form-check-input" id="id_checkboxes_1" name="checkboxes"
+                    type="checkbox" value="2"><label class="form-check-label" for="id_checkboxes_1">Option two</label>
+            </div>
+            <div class="form-check"><input class="form-check-input" id="id_checkboxes_2" name="checkboxes"
+                    type="checkbox" value="3"><label class="form-check-label" for="id_checkboxes_2">Option three</label>
+            </div>
+        </div>
+    </div>
+    <div class="form-group" id="div_id_alphacheckboxes"><label class=" requiredField" for="">Alphacheckboxes<span
+                class="asteriskField">*</span></label>
+        <div class="">
+            <div class="form-check form-check-inline"><input class="form-check-input" id="id_alphacheckboxes_0"
+                    name="alphacheckboxes" type="checkbox" value="option_one"><label class="form-check-label"
+                    for="id_alphacheckboxes_0">Option one</label></div>
+            <div class="form-check form-check-inline"><input checked="checked" class="form-check-input" id="id_alphacheckboxes_1"
+                    name="alphacheckboxes" type="checkbox" value="option_two"><label class="form-check-label"
+                    for="id_alphacheckboxes_1">Option two</label></div>
+            <div class="form-check form-check-inline"><input checked="checked" class="form-check-input" id="id_alphacheckboxes_2"
+                    name="alphacheckboxes" type="checkbox" value="option_three"><label class="form-check-label"
+                    for="id_alphacheckboxes_2">Option three</label></div>
+        </div>
+    </div>
+    <div class="form-group" id="div_id_numeric_multiple_checkboxes"><label class=" requiredField" for="">Numeric multiple
+            checkboxes<span class="asteriskField">*</span></label>
+        <div class="">
+            <div class="form-check"><input checked="checked" class="form-check-input" id="id_numeric_multiple_checkboxes_0"
+                    name="numeric_multiple_checkboxes" type="checkbox" value="1"><label class="form-check-label"
+                    for="id_numeric_multiple_checkboxes_0">Option one</label></div>
+            <div class="form-check"><input checked="checked" class="form-check-input" id="id_numeric_multiple_checkboxes_1"
+                    name="numeric_multiple_checkboxes" type="checkbox" value="2"><label class="form-check-label"
+                    for="id_numeric_multiple_checkboxes_1">Option two</label></div>
+            <div class="form-check"><input class="form-check-input" id="id_numeric_multiple_checkboxes_2"
+                    name="numeric_multiple_checkboxes" type="checkbox" value="3"><label class="form-check-label"
+                    for="id_numeric_multiple_checkboxes_2">Option three</label></div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_true.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_true.html
@@ -1,7 +1,7 @@
 <form method="post">
     <div class="form-group" id="div_id_checkboxes"><label class=" requiredField" for="">Checkboxes<span
                 class="asteriskField">*</span></label>
-        <div class="">
+        <div>
             <div class="custom-checkbox custom-control"><input checked="checked" class="custom-control-input" id="id_checkboxes_0"
                     name="checkboxes" type="checkbox" value="1"><label class="custom-control-label"
                     for="id_checkboxes_0">Option one</label></div>
@@ -15,7 +15,7 @@
     </div>
     <div class="form-group" id="div_id_alphacheckboxes"><label class=" requiredField" for="">Alphacheckboxes<span
                 class="asteriskField">*</span></label>
-        <div class="">
+        <div>
             <div class="custom-checkbox custom-control custom-control-inline"><input class="custom-control-input"
                     id="id_alphacheckboxes_0" name="alphacheckboxes" type="checkbox" value="option_one"><label
                     class="custom-control-label" for="id_alphacheckboxes_0">Option one</label></div>
@@ -31,7 +31,7 @@
     </div>
     <div class="form-group" id="div_id_numeric_multiple_checkboxes"><label class=" requiredField" for="">Numeric multiple
             checkboxes<span class="asteriskField">*</span></label>
-        <div class="">
+        <div>
             <div class="custom-checkbox custom-control"><input checked="checked" class="custom-control-input"
                     id="id_numeric_multiple_checkboxes_0" name="numeric_multiple_checkboxes" type="checkbox"
                     value="1"><label class="custom-control-label" for="id_numeric_multiple_checkboxes_0">Option

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_true.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_true.html
@@ -1,0 +1,49 @@
+<form method="post">
+    <div class="form-group" id="div_id_checkboxes"><label class=" requiredField" for="">Checkboxes<span
+                class="asteriskField">*</span></label>
+        <div class="">
+            <div class="custom-checkbox custom-control"><input checked="checked" class="custom-control-input" id="id_checkboxes_0"
+                    name="checkboxes" type="checkbox" value="1"><label class="custom-control-label"
+                    for="id_checkboxes_0">Option one</label></div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input" id="id_checkboxes_1"
+                    name="checkboxes" type="checkbox" value="2"><label class="custom-control-label"
+                    for="id_checkboxes_1">Option two</label></div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input" id="id_checkboxes_2"
+                    name="checkboxes" type="checkbox" value="3"><label class="custom-control-label"
+                    for="id_checkboxes_2">Option three</label></div>
+        </div>
+    </div>
+    <div class="form-group" id="div_id_alphacheckboxes"><label class=" requiredField" for="">Alphacheckboxes<span
+                class="asteriskField">*</span></label>
+        <div class="">
+            <div class="custom-checkbox custom-control custom-control-inline"><input class="custom-control-input"
+                    id="id_alphacheckboxes_0" name="alphacheckboxes" type="checkbox" value="option_one"><label
+                    class="custom-control-label" for="id_alphacheckboxes_0">Option one</label></div>
+            <div class="custom-checkbox custom-control custom-control-inline"><input checked="checked"
+                    class="custom-control-input" id="id_alphacheckboxes_1" name="alphacheckboxes" type="checkbox"
+                    value="option_two"><label class="custom-control-label" for="id_alphacheckboxes_1">Option two</label>
+            </div>
+            <div class="custom-checkbox custom-control custom-control-inline"><input checked="checked"
+                    class="custom-control-input" id="id_alphacheckboxes_2" name="alphacheckboxes" type="checkbox"
+                    value="option_three"><label class="custom-control-label" for="id_alphacheckboxes_2">Option
+                    three</label></div>
+        </div>
+    </div>
+    <div class="form-group" id="div_id_numeric_multiple_checkboxes"><label class=" requiredField" for="">Numeric multiple
+            checkboxes<span class="asteriskField">*</span></label>
+        <div class="">
+            <div class="custom-checkbox custom-control"><input checked="checked" class="custom-control-input"
+                    id="id_numeric_multiple_checkboxes_0" name="numeric_multiple_checkboxes" type="checkbox"
+                    value="1"><label class="custom-control-label" for="id_numeric_multiple_checkboxes_0">Option
+                    one</label></div>
+            <div class="custom-checkbox custom-control"><input checked="checked" class="custom-control-input"
+                    id="id_numeric_multiple_checkboxes_1" name="numeric_multiple_checkboxes" type="checkbox"
+                    value="2"><label class="custom-control-label" for="id_numeric_multiple_checkboxes_1">Option
+                    two</label></div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input"
+                    id="id_numeric_multiple_checkboxes_2" name="numeric_multiple_checkboxes" type="checkbox"
+                    value="3"><label class="custom-control-label" for="id_numeric_multiple_checkboxes_2">Option
+                    three</label></div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_false.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_false.html
@@ -1,5 +1,5 @@
 <form method="post">
-    <div class="form-group" id="div_id_radio_select"><label class="requiredField" for="id_radio_select_0">Radio
+    <div class="form-group" id="div_id_radio_select"><label class=" requiredField" for="id_radio_select_0">Radio
             select<span class="asteriskField">*</span></label>
         <div>
             <div class="form-check"><input class="form-check-input" id="id_radio_select_0" name="radio_select"

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_false.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_false.html
@@ -1,0 +1,14 @@
+<form method="post">
+    <div class="form-group" id="div_id_radio_select"><label class="requiredField" for="id_radio_select_0">Radio
+            select<span class="asteriskField">*</span></label>
+        <div>
+            <div class="form-check"><input class="form-check-input" id="id_radio_select_0" name="radio_select"
+                    type="radio" value="1"><label class="form-check-label" for="id_radio_select_0">1</label></div>
+            <div class="form-check"><input class="form-check-input" id="id_radio_select_1" name="radio_select"
+                    type="radio" value="2"><label class="form-check-label" for="id_radio_select_1">2</label></div>
+            <div class="form-check"><input class="form-check-input" id="id_radio_select_2" name="radio_select"
+                    type="radio" value="1000"><label class="form-check-label" for="id_radio_select_2">1000</label>
+            </div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_true.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_true.html
@@ -1,8 +1,8 @@
 <form method="post">
-    <div class="form-group" id="div_id_radio_select"><label class="requiredField" for="id_radio_select_0">Radio
+    <div class="form-group" id="div_id_radio_select"><label class=" requiredField" for="id_radio_select_0">Radio
             select<span class="asteriskField">*</span></label>
         <div>
-            <div class=" custom-control custom-radio"><input class="custom-control-input" id="id_radio_select_0"
+            <div class="custom-control custom-radio"><input class="custom-control-input" id="id_radio_select_0"
                     name="radio_select" type="radio" value="1"><label class="custom-control-label"
                     for="id_radio_select_0">1</label></div>
             <div class="custom-control custom-radio"><input class="custom-control-input" id="id_radio_select_1"

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_true.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_true.html
@@ -1,0 +1,16 @@
+<form method="post">
+    <div class="form-group" id="div_id_radio_select"><label class="requiredField" for="id_radio_select_0">Radio
+            select<span class="asteriskField">*</span></label>
+        <div>
+            <div class=" custom-control custom-radio"><input class="custom-control-input" id="id_radio_select_0"
+                    name="radio_select" type="radio" value="1"><label class="custom-control-label"
+                    for="id_radio_select_0">1</label></div>
+            <div class="custom-control custom-radio"><input class="custom-control-input" id="id_radio_select_1"
+                    name="radio_select" type="radio" value="2"><label class="custom-control-label"
+                    for="id_radio_select_1">2</label></div>
+            <div class="custom-control custom-radio"><input class="custom-control-input" id="id_radio_select_2"
+                    name="radio_select" type="radio" value="1000"><label class="custom-control-label"
+                    for="id_radio_select_2">1000</label></div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -585,32 +585,36 @@ def test_keepcontext_context_manager(settings):
 def test_use_custom_control_is_used_in_checkboxes():
     form = CheckboxesSampleForm()
     form.helper = FormHelper()
-    form.helper.layout = Layout("checkboxes", InlineCheckboxes("alphacheckboxes"), "numeric_multiple_checkboxes")
+    form.helper.layout = Layout(
+        "checkboxes",
+        InlineCheckboxes("alphacheckboxes"),
+        "numeric_multiple_checkboxes",
+    )
     # form.helper.use_custom_control take default value which is True
-
-    response = render(request=None, template_name="crispy_render_template.html", context={"form": form})
-    assert response.content.count(b"custom-control-inline") == 3
-    assert response.content.count(b"custom-checkbox") == 9
+    assert parse_form(form) == parse_expected(
+        "bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_true.html"
+    )
 
     form.helper.use_custom_control = True
-
-    response = render(request=None, template_name="crispy_render_template.html", context={"form": form})
-    assert response.content.count(b"custom-control-inline") == 3
-    assert response.content.count(b"custom-checkbox") == 9
+    assert parse_form(form) == parse_expected(
+        "bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_true.html"
+    )
 
     form.helper.use_custom_control = False
-
-    response = render(request=None, template_name="crispy_render_template.html", context={"form": form})
-
-    assert response.content.count(b"custom-control-inline") == 0
-    assert response.content.count(b"form-check-inline") == 3
-    assert response.content.count(b"form-check") > 0
-    assert response.content.count(b"custom-checkbox") == 0
+    assert parse_form(form) == parse_expected(
+        "bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_false.html"
+    )
 
 
 @only_bootstrap4
-@pytest.mark.parametrize("use_custom_control, custom_select_count", [(True, 1), (False, 0)])
-def test_use_custom_control_in_select(use_custom_control, custom_select_count):
+@pytest.mark.parametrize(
+    "use_custom_control, expected_html",
+    [
+        (True, "bootstrap4/test_layout/test_use_custom_control_in_select_true.html"),
+        (False, "bootstrap4/test_layout/test_use_custom_control_in_select_false.html"),
+    ],
+)
+def test_use_custom_control_in_select(use_custom_control, expected_html):
     form = SelectSampleForm()
 
     form.helper = FormHelper()
@@ -618,9 +622,7 @@ def test_use_custom_control_in_select(use_custom_control, custom_select_count):
     form.helper.layout = Layout("select")
     form.helper.use_custom_control = use_custom_control
 
-    html = render_crispy_form(form)
-
-    assert html.count("custom-select") == custom_select_count
+    assert parse_form(form) == parse_expected(expected_html)
 
 
 @only_bootstrap3

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -606,6 +606,7 @@ def test_use_custom_control_is_used_in_checkboxes():
         "bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_false.html"
     )
 
+
 @only_bootstrap4
 def test_use_custom_control_is_used_in_radio():
     form = SampleForm5()

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -24,6 +24,7 @@ from .forms import (
     SampleForm2,
     SampleForm3,
     SampleForm4,
+    SampleForm5,
     SampleForm6,
     SelectSampleForm,
 )
@@ -603,6 +604,28 @@ def test_use_custom_control_is_used_in_checkboxes():
     form.helper.use_custom_control = False
     assert parse_form(form) == parse_expected(
         "bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_false.html"
+    )
+
+@only_bootstrap4
+def test_use_custom_control_is_used_in_radio():
+    form = SampleForm5()
+    form.helper = FormHelper()
+    form.helper.layout = Layout(
+        "radio_select",
+    )
+    # form.helper.use_custom_control take default value which is True
+    assert parse_form(form) == parse_expected(
+        "bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_true.html"
+    )
+
+    form.helper.use_custom_control = True
+    assert parse_form(form) == parse_expected(
+        "bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_true.html"
+    )
+
+    form.helper.use_custom_control = False
+    assert parse_form(form) == parse_expected(
+        "bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_false.html"
     )
 
 


### PR DESCRIPTION
This is part of the work to use the new `optgroups` filter. We need better test coverage of the rendered HTML so we can easily see any changes when I change the templates. 

I've also structured the existing tests better in a separate commit. The logic is now each batch of HTML "result" files are saved under the convention of `{template pack}/{test file name}/{test name}{test identified (if required)}.html`.

Finally, it seems we have good coverage of checkboxes, but we should have the same for radios.