### PR TITLE
Zero index checkbox and radio in bootstrap templates

### DIFF
--- a/crispy_forms/templates/bootstrap/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap/layout/checkboxselectmultiple.html
@@ -5,8 +5,8 @@
     {% include 'bootstrap/layout/field_errors_block.html' %}
 
     {% for choice in field.field.choices %}
-        <label class="checkbox{% if inline_class %} {{ inline_class }}{% endif %}" for="id_{{ field.html_name }}_{{ forloop.counter }}">
-            <input type="checkbox"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>{{ choice.1|unlocalize }}
+        <label class="checkbox{% if inline_class %} {{ inline_class }}{% endif %}" for="id_{{ field.html_name }}_{{ forloop.counter0 }}">
+            <input type="checkbox"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter0 }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>{{ choice.1|unlocalize }}
         </label>
     {% endfor %}
 

--- a/crispy_forms/templates/bootstrap/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap/layout/radioselect.html
@@ -5,8 +5,8 @@
     {% include 'bootstrap/layout/field_errors_block.html' %}
 
     {% for choice in field.field.choices %}
-        <label for="id_{{ field.html_name }}_{{ forloop.counter }}" class="radio{% if inline_class %} {{ inline_class }}{% endif %}">
-            <input type="radio"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>{{ choice.1|unlocalize }}
+        <label for="id_{{ field.html_name }}_{{ forloop.counter0 }}" class="radio{% if inline_class %} {{ inline_class }}{% endif %}">
+            <input type="radio"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter0 }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>{{ choice.1|unlocalize }}
         </label>
     {% endfor %}
 

--- a/crispy_forms/templates/bootstrap3/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap3/layout/checkboxselectmultiple.html
@@ -7,8 +7,8 @@
     {% for choice in field.field.choices %}
 
       {% if not inline_class %}<div class="checkbox">{% endif %}
-        <label class="{% if inline_class %}checkbox-{{ inline_class }}{% endif %}" for="id_{{ field.html_name }}_{{ forloop.counter }}">
-            <input type="checkbox"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>{{ choice.1|unlocalize }}
+        <label class="{% if inline_class %}checkbox-{{ inline_class }}{% endif %}" for="id_{{ field.html_name }}_{{ forloop.counter0 }}">
+            <input type="checkbox"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter0 }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>{{ choice.1|unlocalize }}
         </label>
       {% if not inline_class %}</div>{% endif %}
     {% endfor %}

--- a/crispy_forms/templates/bootstrap3/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap3/layout/radioselect.html
@@ -6,8 +6,8 @@
 
     {% for choice in field.field.choices %}
       {% if not inline_class %}<div class="radio">{% endif %}
-        <label for="id_{{ field.html_name }}_{{ forloop.counter }}" class="{% if inline_class %}radio-{{ inline_class }}{% endif %}">
-            <input type="radio"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>{{ choice.1|unlocalize }}
+        <label for="id_{{ field.html_name }}_{{ forloop.counter0 }}" class="{% if inline_class %}radio-{{ inline_class }}{% endif %}">
+            <input type="radio"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter0 }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>{{ choice.1|unlocalize }}
         </label>
       {% if not inline_class %}</div>{% endif %}
     {% endfor %}

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
@@ -5,8 +5,8 @@
 
     {% for choice in field.field.choices %}
     <div class="{%if use_custom_control%}custom-control custom-checkbox{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">
-        <input type="checkbox" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{% if field.errors %} is-invalid{% endif %}"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>
-        <label class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}" for="id_{{ field.html_name }}_{{ forloop.counter }}">
+        <input type="checkbox" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{% if field.errors %} is-invalid{% endif %}"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter0 }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>
+        <label class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}" for="id_{{ field.html_name }}_{{ forloop.counter0 }}">
             {{ choice.1|unlocalize }}
         </label>
         {% if field.errors and forloop.last and not inline_class %}

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -5,8 +5,8 @@
 
     {% for choice in field.field.choices %}
       <div class="{%if use_custom_control%}custom-control custom-radio{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">
-        <input type="radio" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{% if field.errors %} is-invalid{% endif %}"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>
-        <label for="id_{{ field.html_name }}_{{ forloop.counter }}" class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}">
+        <input type="radio" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{% if field.errors %} is-invalid{% endif %}"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked="checked"{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter0 }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>
+        <label for="id_{{ field.html_name }}_{{ forloop.counter0 }}" class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}">
             {{ choice.1|unlocalize }}
         </label>
         {% if field.errors and forloop.last and not inline_class %}

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -521,16 +521,16 @@ class TestBootstrapLayoutObjects:
         html = render_crispy_form(test_form)
 
         expected_ids = [
+            "checkboxes_0",
             "checkboxes_1",
             "checkboxes_2",
-            "checkboxes_3",
+            "alphacheckboxes_0",
             "alphacheckboxes_1",
             "alphacheckboxes_2",
-            "alphacheckboxes_3",
+            "numeric_multiple_checkboxes_0",
             "numeric_multiple_checkboxes_1",
             "numeric_multiple_checkboxes_2",
-            "numeric_multiple_checkboxes_3",
         ]
         for id_suffix in expected_ids:
-            expected_str = 'id="id_{id_suffix}"'.format(id_suffix=id_suffix)
+            expected_str = f'id="id_{id_suffix}"'
             assert html.count(expected_str) == 1


### PR DESCRIPTION
When we move to the new optgroups filter the ids for the inputs will be start from zero rather than one. I'm making this change now so we have a smaller diff later on. (or atleast that's the intention!)

I'm wondering if this is backwards incompattible change? Any comments? 