### PR TITLE
Refactored field_class for mutiple checkboxes and radios

### DIFF
--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<div class="{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+<div {% if field_class %}class="{{ field_class }}"{% endif %}{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
 
     {% for choice in field.field.choices %}
     <div class="{%if use_custom_control%}custom-control custom-checkbox{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<div class="{% if field_class %} {{ field_class }}{% endif %}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+<div {% if field_class %}class="{{ field_class }}"{% endif %}{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
 
     {% for choice in field.field.choices %}
       <div class="{%if use_custom_control%}custom-control custom-radio{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">


### PR DESCRIPTION
Where field class is null currenrtly `<div class="">` is rendered.
This change results in only `<div>` being rendered in this case.