### PR TITLE
Fixed Grouped Choices for Radios and Checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG for django-crispy-forms
 
 ## Next Release (TBC)
+* Fixed rendering of grouped checkboxes and radio inputs in the Bootstrap 4 template pack. (#1155)
 * Introduced new `input_size` argument to `AppendedText`, `PrependedText` and `PrependedAppendedText`. This allows
   the size of these grouped inputs to be changed in the Bootstrap 4 template pack. (#1114)
 * Confirmed support for Django 3.2

--- a/crispy_forms/templates/bootstrap4/layout/attrs.html
+++ b/crispy_forms/templates/bootstrap4/layout/attrs.html
@@ -1,0 +1,1 @@
+{% for name, value in widget.attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
@@ -3,16 +3,19 @@
 
 <div {% if field_class %}class="{{ field_class }}"{% endif %}{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
 
-    {% for choice in field.field.choices %}
+    {% for group, options, index in field|optgroups %}
+    {% if group %}<strong>{{ group }}</strong>{% endif %}
+    {% for option in options %}
     <div class="{%if use_custom_control%}custom-control custom-checkbox{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">
-        <input type="checkbox" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{% if field.errors %} is-invalid{% endif %}"{% if choice.0 in field.value or choice.0|stringformat:"s" in field.value or choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter0 }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>
-        <label class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}" for="id_{{ field.html_name }}_{{ forloop.counter0 }}">
-            {{ choice.1|unlocalize }}
+        <input type="checkbox" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{% if field.errors %} is-invalid{% endif %}" name="{{ field.html_name }}" value="{{ option.value|unlocalize }}" {% include "bootstrap4/layout/attrs.html" with widget=option %}>
+        <label class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}" for="{{ option.attrs.id }}">
+            {{ option.label|unlocalize }}
         </label>
         {% if field.errors and forloop.last and not inline_class %}
             {% include 'bootstrap4/layout/field_errors_block.html' %}
             {% endif %}
     </div>
+   {% endfor %}
    {% endfor %}
     {% if field.errors and inline_class %}
     <div class="w-100 {%if use_custom_control%}custom-control custom-checkbox{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -3,16 +3,19 @@
 
 <div {% if field_class %}class="{{ field_class }}"{% endif %}{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
 
-    {% for choice in field.field.choices %}
+    {% for group, options, index in field|optgroups %}
+    {% if group %}<strong>{{ group }}</strong>{% endif %}
+    {% for option in options %}
       <div class="{%if use_custom_control%}custom-control custom-radio{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">
-        <input type="radio" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{% if field.errors %} is-invalid{% endif %}"{% if choice.0|stringformat:"s" == field.value|default_if_none:""|stringformat:"s" %} checked{% endif %} name="{{ field.html_name }}" id="id_{{ field.html_name }}_{{ forloop.counter0 }}" value="{{ choice.0|unlocalize }}" {% if field.field.disabled %}disabled="true"{% endif %} {{ field.field.widget.attrs|flatatt }}>
-        <label for="id_{{ field.html_name }}_{{ forloop.counter0 }}" class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}">
-            {{ choice.1|unlocalize }}
+        <input type="radio" class="{%if use_custom_control%}custom-control-input{% else %}form-check-input{% endif %}{% if field.errors %} is-invalid{% endif %}" name="{{ field.html_name }}" value="{{ option.value|unlocalize }}" {% include "bootstrap4/layout/attrs.html" with widget=option %}>
+        <label class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}" for="{{ option.attrs.id }}">
+            {{ option.label|unlocalize }}
         </label>
         {% if field.errors and forloop.last and not inline_class %}
             {% include 'bootstrap4/layout/field_errors_block.html' %}
         {% endif %}
      </div>
+    {% endfor %}
     {% endfor %}
     {% if field.errors and inline_class %}
     <div class="w-100 {%if use_custom_control%}custom-control custom-radio{% if inline_class %} custom-control-inline{% endif %}{% else %}form-check{% if inline_class %} form-check-inline{% endif %}{% endif %}">

--- a/crispy_forms/tests/forms.py
+++ b/crispy_forms/tests/forms.py
@@ -203,6 +203,7 @@ class GroupedChoiceForm(forms.Form):
         ("unknown", "Unknown"),
     ]
     checkbox_select_multiple = forms.MultipleChoiceField(widget=forms.CheckboxSelectMultiple, choices=choices)
+    radio = forms.MultipleChoiceField(widget=forms.RadioSelect, choices=choices)
 
 
 class CustomRadioSelect(forms.RadioSelect):

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_false.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_false.html
@@ -3,11 +3,11 @@
             select<span class="asteriskField">*</span></label>
         <div>
             <div class="form-check"><input class="form-check-input" id="id_radio_select_0" name="radio_select"
-                    type="radio" value="1"><label class="form-check-label" for="id_radio_select_0">1</label></div>
+                    type="radio" value="1" required><label class="form-check-label" for="id_radio_select_0">1</label></div>
             <div class="form-check"><input class="form-check-input" id="id_radio_select_1" name="radio_select"
-                    type="radio" value="2"><label class="form-check-label" for="id_radio_select_1">2</label></div>
+                    type="radio" value="2" required><label class="form-check-label" for="id_radio_select_1">2</label></div>
             <div class="form-check"><input class="form-check-input" id="id_radio_select_2" name="radio_select"
-                    type="radio" value="1000"><label class="form-check-label" for="id_radio_select_2">1000</label>
+                    type="radio" value="1000" required><label class="form-check-label" for="id_radio_select_2">1000</label>
             </div>
         </div>
     </div>

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_true.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_true.html
@@ -3,13 +3,13 @@
             select<span class="asteriskField">*</span></label>
         <div>
             <div class="custom-control custom-radio"><input class="custom-control-input" id="id_radio_select_0"
-                    name="radio_select" type="radio" value="1"><label class="custom-control-label"
+                    name="radio_select" type="radio" value="1" required><label class="custom-control-label"
                     for="id_radio_select_0">1</label></div>
             <div class="custom-control custom-radio"><input class="custom-control-input" id="id_radio_select_1"
-                    name="radio_select" type="radio" value="2"><label class="custom-control-label"
+                    name="radio_select" type="radio" value="2" required><label class="custom-control-label"
                     for="id_radio_select_1">2</label></div>
             <div class="custom-control custom-radio"><input class="custom-control-input" id="id_radio_select_2"
-                    name="radio_select" type="radio" value="1000"><label class="custom-control-label"
+                    name="radio_select" type="radio" value="1000" required><label class="custom-control-label"
                     for="id_radio_select_2">1000</label></div>
         </div>
     </div>

--- a/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_grouped_checkboxes.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_grouped_checkboxes.html
@@ -1,0 +1,30 @@
+
+<form method="post">
+    <div class="form-group" id="div_id_checkbox_select_multiple"><label class=" requiredField">Checkbox select
+            multiple<span class="asteriskField">*</span></label>
+        <div>
+            <strong>Audio</strong>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input"
+                    id="id_checkbox_select_multiple_0_0" name="checkbox_select_multiple" type="checkbox"
+                    value="vinyl"><label class="custom-control-label"
+                    for="id_checkbox_select_multiple_0_0">Vinyl</label></div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input"
+                    id="id_checkbox_select_multiple_0_1" name="checkbox_select_multiple" type="checkbox"
+                    value="cd"><label class="custom-control-label" for="id_checkbox_select_multiple_0_1">CD</label>
+            </div>
+            <strong>Video</strong>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input"
+                    id="id_checkbox_select_multiple_1_0" name="checkbox_select_multiple" type="checkbox"
+                    value="vhs"><label class="custom-control-label" for="id_checkbox_select_multiple_1_0">VHS
+                    Tape</label></div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input"
+                    id="id_checkbox_select_multiple_1_1" name="checkbox_select_multiple" type="checkbox"
+                    value="dvd"><label class="custom-control-label" for="id_checkbox_select_multiple_1_1">DVD</label>
+            </div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input"
+                    id="id_checkbox_select_multiple_2" name="checkbox_select_multiple" type="checkbox"
+                    value="unknown"><label class="custom-control-label"
+                    for="id_checkbox_select_multiple_2">Unknown</label></div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_grouped_radios.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_grouped_radios.html
@@ -1,0 +1,24 @@
+<form method="post">
+    <div class="form-group" id="div_id_radio"><label class=" requiredField" for="id_radio_0">Radio<span
+                class="asteriskField">*</span></label>
+        <div>
+            <strong>Audio</strong>
+            <div class="custom-control custom-radio"><input class="custom-control-input" id="id_radio_0_0" name="radio"
+                    required type="radio" value="vinyl"><label class="custom-control-label"
+                    for="id_radio_0_0">Vinyl</label></div>
+            <div class="custom-control custom-radio"><input class="custom-control-input" id="id_radio_0_1" name="radio"
+                    required type="radio" value="cd"><label class="custom-control-label" for="id_radio_0_1">CD</label>
+            </div>
+            <strong>Video</strong>
+            <div class="custom-control custom-radio"><input class="custom-control-input" id="id_radio_1_0" name="radio"
+                    required type="radio" value="vhs"><label class="custom-control-label" for="id_radio_1_0">VHS
+                    Tape</label></div>
+            <div class="custom-control custom-radio"><input class="custom-control-input" id="id_radio_1_1" name="radio"
+                    required type="radio" value="dvd"><label class="custom-control-label" for="id_radio_1_1">DVD</label>
+            </div>
+            <div class="custom-control custom-radio"><input class="custom-control-input" id="id_radio_2" name="radio"
+                    required type="radio" value="unknown"><label class="custom-control-label"
+                    for="id_radio_2">Unknown</label></div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -30,9 +30,11 @@ from .forms import (
     CheckboxesSampleForm,
     CustomCheckboxSelectMultiple,
     CustomRadioSelect,
+    GroupedChoiceForm,
     SampleForm,
     SampleFormCustomWidgets,
 )
+from .utils import parse_expected, parse_form
 
 
 def test_field_with_custom_template():
@@ -535,3 +537,12 @@ class TestBootstrapLayoutObjects:
         for id_suffix in expected_ids:
             expected_str = f'id="id_{id_suffix}"'
             assert html.count(expected_str) == 1
+
+    @only_bootstrap4
+    def test_grouped_checkboxes_radios(self):
+        form = GroupedChoiceForm()
+        form.helper = FormHelper()
+        form.helper.layout = Layout("checkbox_select_multiple")
+        assert parse_form(form) == parse_expected("bootstrap4/test_layout_objects/test_grouped_checkboxes.html")
+        form.helper.layout = Layout("radio")
+        assert parse_form(form) == parse_expected("bootstrap4/test_layout_objects/test_grouped_radios.html")


### PR DESCRIPTION
So here we are 🎉 This fixes the long standing bug with grouped choices sets.

Fixes #690 and Follows #1119 and #813

I'll leave this here for comments, and look at pulling some of the related changes into separate PRs. There's also a few things which I want to take a closer look at. 

- [x] Show image of before / after
- [x] Release notes
- [x] What's happening with the new `required` attribute on `test_use_custom_control_is_used_in_radio_true.html`
- [x] of course the tests fail on Django 2.2