### PR TITLE
Fixed Bootstrap4 Field with buttons input size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Added support for Python 3.10
 * Dropped support for Django 3.1
 * Dropped support for Python 3.6
+* Added `input_size` argument to `FieldWithButtons` to allow customisation of the size of the input in the Bootstrap 4 
+  template pack. (#1159)
 
 ## 1.13.0 (2021-09-25)
 * Added support for Django 4.0

--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -133,6 +133,29 @@ class InlineRadios(Field):
 
 
 class FieldWithButtons(Div):
+    """
+    A layout object for rendering a single field with any number of buttons.
+
+    Args:
+        fields : str or LayoutObject
+            The first positional argument is the field. This can be either the
+            name of the field as a string or an instance of `Field`. Following
+            arguments will be rendered as buttons.
+        input_size : str
+            Additional CSS class to change the size of the input. e.g.
+            "input-group-sm".
+        kwargs
+            Additional kwargs to be passed to the parent `Div` Layout Object.
+
+    Example::
+
+        FieldWithButtons(
+            Field("password1", css_class="span4"),
+            StrictButton("Go!", css_id="go-button"),
+            input_size="input-group-sm",
+        )
+    """
+
     template = "%s/layout/field_with_buttons.html"
     field_template = "%s/field.html"
 

--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -136,6 +136,10 @@ class FieldWithButtons(Div):
     template = "%s/layout/field_with_buttons.html"
     field_template = "%s/field.html"
 
+    def __init__(self, *fields, input_size=None, **kwargs):
+        self.input_size = input_size
+        super().__init__(*fields, **kwargs)
+
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, extra_context=None, **kwargs):
         # We first render the buttons
         field_template = self.field_template % template_pack

--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -9,7 +9,7 @@
 
     <div class="{{ field_class }}">
         <div class="input-group {% if div.input_size %} {{ div.input_size }}{% endif %}">
-            {% crispy_field field %}
+            {% crispy_field field 'class' 'form-control' %}
             <span class="input-group-append{% if active %} active{% endif %}">{{ buttons|safe }}</span>
         </div>
         {% include 'bootstrap4/layout/help_text_and_errors.html' %}

--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -8,9 +8,9 @@
     {% endif %}
 
     <div class="{{ field_class }}">
-        <div class="input-group">
+        <div class="input-group {% if div.input_size %} {{ div.input_size }}{% endif %}">
             {% crispy_field field %}
-            <span class="input-group-append{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ buttons|safe }}</span>
+            <span class="input-group-append{% if active %} active{% endif %}">{{ buttons|safe }}</span>
         </div>
         {% include 'bootstrap4/layout/help_text_and_errors.html' %}
     </div>

--- a/crispy_forms/tests/results/bootstrap/test_layout_objects/test_field_with_buttons.html
+++ b/crispy_forms/tests/results/bootstrap/test_layout_objects/test_field_with_buttons.html
@@ -1,0 +1,11 @@
+<form method="post">
+    <div class="control-group extra" autocomplete="off"> <label for="id_password1" class="control-label requiredField">
+            password<span class="asteriskField">*</span> </label>
+        <div class="controls">
+            <div class="input-append"> <input type="password" name="password1" maxlength="30"
+                    class="span4 textinput textInput" required id="id_password1"> <button class="btn" id="go-button"
+                    type="button">Go!</button><button class="btn extra" type="button">No!</button><button class="btn"
+                    name="whatever" type="submit" value="something">Test</button> </div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap3/test_layout_objects/test_field_with_buttons.html
+++ b/crispy_forms/tests/results/bootstrap3/test_layout_objects/test_field_with_buttons.html
@@ -3,7 +3,7 @@
             password<span class="asteriskField">*</span> </label>
         <div class="controls ">
             <div class="input-group"> <input type="password" name="password1" maxlength="30"
-                    class="span4 textinput textInput form-control" required id="id_password1"> <span
+                    class="span4 textinput textInput" required id="id_password1"> <span
                     class="input-group-btn"><button class="btn" id="go-button" type="button">Go!</button><button
                         class="btn extra" type="button">No!</button><button class="btn" name="whatever" type="submit"
                         value="something">Test</button></span> </div>

--- a/crispy_forms/tests/results/bootstrap3/test_layout_objects/test_field_with_buttons.html
+++ b/crispy_forms/tests/results/bootstrap3/test_layout_objects/test_field_with_buttons.html
@@ -1,0 +1,12 @@
+<form method="post">
+    <div class="form-group extra" autocomplete="off"> <label for="id_password1" class="control-label  requiredField">
+            password<span class="asteriskField">*</span> </label>
+        <div class="controls ">
+            <div class="input-group"> <input type="password" name="password1" maxlength="30"
+                    class="span4 textinput textInput form-control" required id="id_password1"> <span
+                    class="input-group-btn"><button class="btn" id="go-button" type="button">Go!</button><button
+                        class="btn extra" type="button">No!</button><button class="btn" name="whatever" type="submit"
+                        value="something">Test</button></span> </div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_field_with_buttons.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_field_with_buttons.html
@@ -2,7 +2,7 @@
     <div class="form-group extra" autocomplete="off"> <label for="id_password1" class=" requiredField"> password<span
                 class="asteriskField">*</span> </label>
         <div class="">
-            <div class="input-group"> <input type="password" name="password1" maxlength="30"
+            <div class="input-group input-group-sm"> <input type="password" name="password1" maxlength="30"
                     class="span4 textinput textInput form-control" required id="id_password1"> <span
                     class="input-group-append"><button class="btn" id="go-button" type="button">Go!</button><button
                         class="btn extra" type="button">No!</button><button class="btn" name="whatever" type="submit"

--- a/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_field_with_buttons.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_field_with_buttons.html
@@ -2,11 +2,15 @@
     <div class="form-group extra" autocomplete="off"> <label for="id_password1" class=" requiredField"> password<span
                 class="asteriskField">*</span> </label>
         <div class="">
-            <div class="input-group input-group-sm"> <input type="password" name="password1" maxlength="30"
-                    class="span4 textinput textInput form-control" required id="id_password1"> <span
-                    class="input-group-append"><button class="btn" id="go-button" type="button">Go!</button><button
-                        class="btn extra" type="button">No!</button><button class="btn" name="whatever" type="submit"
-                        value="something">Test</button></span> </div>
+            <div class=" input-group input-group-sm">
+                <input type="password" name="password1" maxlength="30" class="span4 textinput textInput form-control"
+                    required id="id_password1">
+                <span class="input-group-append">
+                    <button class="btn" id="go-button" type="button">Go!</button>
+                    <button class="btn extra" type="button">No!</button>
+                    <button class="btn" name="whatever" type="submit" value="something">Test</button>
+                </span>
+            </div>
         </div>
     </div>
 </form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_field_with_buttons.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_field_with_buttons.html
@@ -1,0 +1,12 @@
+<form method="post">
+    <div class="form-group extra" autocomplete="off"> <label for="id_password1" class=" requiredField"> password<span
+                class="asteriskField">*</span> </label>
+        <div class="">
+            <div class="input-group"> <input type="password" name="password1" maxlength="30"
+                    class="span4 textinput textInput form-control" required id="id_password1"> <span
+                    class="input-group-append"><button class="btn" id="go-button" type="button">Go!</button><button
+                        class="btn extra" type="button">No!</button><button class="btn" name="whatever" type="submit"
+                        value="something">Test</button></span> </div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -35,7 +35,6 @@ from .forms import (
     SampleForm,
     SampleFormCustomWidgets,
 )
-from .utils import parse_expected, parse_form
 
 
 def test_field_with_custom_template():
@@ -465,6 +464,7 @@ class TestBootstrapLayoutObjects:
                 StrictButton("Test", type="submit", name="whatever", value="something"),
                 css_class="extra",
                 autocomplete="off",
+                input_size="input-group-sm",
             )
         )
         assert parse_form(form) == parse_expected(

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -23,7 +23,7 @@ from crispy_forms.bootstrap import (
 )
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import HTML, Field, Layout, MultiWidgetField
-from crispy_forms.tests.utils import contains_partial
+from crispy_forms.tests.utils import contains_partial, parse_expected, parse_form
 from crispy_forms.utils import render_crispy_form
 
 from .conftest import only_bootstrap, only_bootstrap4
@@ -467,30 +467,9 @@ class TestBootstrapLayoutObjects:
                 autocomplete="off",
             )
         )
-        html = render_crispy_form(form)
-
-        form_group_class = "control-group"
-        if settings.CRISPY_TEMPLATE_PACK in ("bootstrap3", "bootstrap4"):
-            form_group_class = "form-group"
-
-        assert html.count('class="%s extra"' % form_group_class) == 1
-        assert html.count('autocomplete="off"') == 1
-        assert html.count('class="span4') == 1
-        assert html.count('id="go-button"') == 1
-        assert html.count("Go!") == 1
-        assert html.count("No!") == 1
-        assert html.count('class="btn"') == 2
-        assert html.count('class="btn extra"') == 1
-        assert html.count('type="submit"') == 1
-        assert html.count('name="whatever"') == 1
-        assert html.count('value="something"') == 1
-
-        if settings.CRISPY_TEMPLATE_PACK == "bootstrap":
-            assert html.count('class="input-append"') == 1
-        elif settings.CRISPY_TEMPLATE_PACK == "bootstrap3":
-            assert html.count('class="input-group-btn') == 1
-        elif settings.CRISPY_TEMPLATE_PACK == "bootstrap4":
-            assert html.count('class="input-group-append') == 1
+        assert parse_form(form) == parse_expected(
+            f"{settings.CRISPY_TEMPLATE_PACK}/test_layout_objects/test_field_with_buttons.html"
+        )
 
     def test_hidden_fields(self):
         form = SampleForm()

--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -252,7 +252,9 @@ These ones live under module ``crispy_forms.bootstrap``.
 
 - **FieldWithButtons**: You can create an input connected with buttons::
 
-    FieldWithButtons('field_name', StrictButton("Go!"))
+    The size of the field can be customised in the Bootstrap4 template pack by passing in the size modifier class to `input_size`. 
+
+    FieldWithButtons('field_name', StrictButton("Go!"), input_size="input-group-sm")
 
 .. image:: images/field_with_buttons.png
    :align: center


### PR DESCRIPTION
@cpina -- Could you have a look at this at some point for me? The first commit is just resturcuting the tests, the second commit is the real change and is much smaller. 

The `FieldWithButtons` class is a little different to the prepend / append inputs so I think the solution needs to be different as well. 

I had a look through the git history and can't quite work out the history of the `input_size` variable that's in the template at the moment. I'm also unsure how you would even use this? 

Key questions that I'm slightly unsure on are both related to way the `__init__` function is structured:

- Does this break backwards compatibility give I've introduced a new `__init__` function with a different structure. I _think_ by adding the new item as a key word only variable this is ok? 
- Is adding this item as a key word argument to `FieldWithButtons` the way folk would want to use it? 