### PR TITLE
Updated uni-form link

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -70,4 +70,4 @@ crispy-forms does not include static files. You will need to include the proper 
  
 
 .. _Django: https://djangoproject.com
-.. _`Uni-form`: https://sprawsm.com/uni-form
+.. _`Uni-form`: https://github.com/draganbabic/uni-form/tree/uni-form-v-1-5


### PR DESCRIPTION
Fixes #1050

Given Uni-Form hasn't had a commit since 2013 it's looking a bit unmaintained to me. I wonder how much longer we should continue to package those templates? I guess putting it into it's own template pack would be the answer...

