### PR TITLE
Allow codecov to fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,4 +51,4 @@ jobs:
       with:
         flags: unittests
         name: codecov-umbrella
-        fail_ci_if_error: true
+        fail_ci_if_error: false

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,9 @@ deps =
     django-latest: https://github.com/django/django/archive/main.tar.gz
     -rrequirements/testing.txt
 allowlist_externals = make
-commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m pytest {posargs} --cov=crispy_forms
+commands =
+    python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m pytest {posargs} --cov=crispy_forms
+    coverage xml -i
 ignore_outcome =
     django-latest: True
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,7 @@ deps =
     django-latest: https://github.com/django/django/archive/main.tar.gz
     -rrequirements/testing.txt
 allowlist_externals = make
-commands =
-    python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m pytest {posargs} --cov=crispy_forms
-    coverage xml -i
+commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m pytest {posargs} --cov=crispy_forms
 ignore_outcome =
     django-latest: True
 setenv =


### PR DESCRIPTION
Codecov has started to fail, see run below. Seems that creating an xml file is the fix for this.
https://github.com/django-crispy-forms/django-crispy-forms/pull/1155/checks?check_run_id=2647114315
https://github.com/codecov/codecov-bash/issues/94

Let's see what the CI has to say about this. 
