### PR TITLE
Fixed error messages for checkboxes and radios

### DIFF
--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
@@ -11,7 +11,7 @@
         <label class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}" for="{{ option.attrs.id }}">
             {{ option.label|unlocalize }}
         </label>
-        {% if field.errors and forloop.last and not inline_class %}
+        {% if field.errors and forloop.last and not inline_class and forloop.parentloop.last %}
             {% include 'bootstrap4/layout/field_errors_block.html' %}
             {% endif %}
     </div>

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -11,7 +11,7 @@
         <label class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}" for="{{ option.attrs.id }}">
             {{ option.label|unlocalize }}
         </label>
-        {% if field.errors and forloop.last and not inline_class %}
+        {% if field.errors and forloop.last and not inline_class and forloop.parentloop.last %}
             {% include 'bootstrap4/layout/field_errors_block.html' %}
         {% endif %}
      </div>

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_true_failing.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_true_failing.html
@@ -1,0 +1,64 @@
+<form method="post">
+    <div class="form-group" id="div_id_checkboxes"><label class=" requiredField">Checkboxes<span
+                class="asteriskField">*</span></label>
+        <div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input is-invalid" id="id_checkboxes_0"
+                    name="checkboxes" type="checkbox" value="1"><label class="custom-control-label"
+                    for="id_checkboxes_0">Option one</label></div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input is-invalid" id="id_checkboxes_1"
+                    name="checkboxes" type="checkbox" value="2"><label class="custom-control-label"
+                    for="id_checkboxes_1">Option two</label></div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input is-invalid" id="id_checkboxes_2"
+                    name="checkboxes" type="checkbox" value="3"><label class="custom-control-label"
+                    for="id_checkboxes_2">Option three</label>
+            <p class="invalid-feedback" id="error_1_id_checkboxes">
+               <strong>This field is required.</strong> 
+            </p>
+            </div>
+        </div>
+    </div>
+    <div class="form-group has-danger" id="div_id_alphacheckboxes"><label class=" requiredField">Alphacheckboxes<span
+                class="asteriskField">*</span></label>
+        <div>
+            <div class="custom-checkbox custom-control custom-control-inline"><input class="custom-control-input is-invalid"
+                    id="id_alphacheckboxes_0" name="alphacheckboxes" type="checkbox" value="option_one"><label
+                    class="custom-control-label" for="id_alphacheckboxes_0">Option one</label></div>
+            <div class="custom-checkbox custom-control custom-control-inline"><input
+                    class="custom-control-input is-invalid" id="id_alphacheckboxes_1" name="alphacheckboxes" type="checkbox"
+                    value="option_two"><label class="custom-control-label" for="id_alphacheckboxes_1">Option two</label>
+            </div>
+            <div class="custom-checkbox custom-control custom-control-inline"><input
+                    class="custom-control-input is-invalid" id="id_alphacheckboxes_2" name="alphacheckboxes" type="checkbox"
+                    value="option_three"><label class="custom-control-label" for="id_alphacheckboxes_2">Option
+                    three</label>
+            </div>
+            <div class="custom-checkbox custom-control custom-control-inline w-100">
+                <input class="custom-control-input is-invalid" type="checkbox">
+                <p class="invalid-feedback" id="error_1_id_alphacheckboxes">
+                   <strong>This field is required.</strong> 
+                </p>
+            </div>
+        </div>
+    </div>
+    <div class="form-group" id="div_id_numeric_multiple_checkboxes"><label class=" requiredField">Numeric multiple
+            checkboxes<span class="asteriskField">*</span></label>
+        <div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input is-invalid"
+                    id="id_numeric_multiple_checkboxes_0" name="numeric_multiple_checkboxes" type="checkbox"
+                    value="1"><label class="custom-control-label" for="id_numeric_multiple_checkboxes_0">Option
+                    one</label></div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input is-invalid"
+                    id="id_numeric_multiple_checkboxes_1" name="numeric_multiple_checkboxes" type="checkbox"
+                    value="2"><label class="custom-control-label" for="id_numeric_multiple_checkboxes_1">Option
+                    two</label></div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input is-invalid"
+                    id="id_numeric_multiple_checkboxes_2" name="numeric_multiple_checkboxes" type="checkbox"
+                    value="3"><label class="custom-control-label" for="id_numeric_multiple_checkboxes_2">Option
+                    three</label>
+            <p class="invalid-feedback" id="error_1_id_numeric_multiple_checkboxes">
+               <strong>This field is required.</strong> 
+            </p>
+            </div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_true_failing.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_true_failing.html
@@ -1,0 +1,20 @@
+<form method="post">
+    <div class="form-group" id="div_id_radio_select"><label class=" requiredField" for="id_radio_select_0">Radio
+            select<span class="asteriskField">*</span></label>
+        <div>
+            <div class="custom-control custom-radio"><input class="custom-control-input is-invalid" id="id_radio_select_0"
+                    name="radio_select" type="radio" value="1" required><label class="custom-control-label"
+                    for="id_radio_select_0">1</label></div>
+            <div class="custom-control custom-radio"><input class="custom-control-input is-invalid" id="id_radio_select_1"
+                    name="radio_select" type="radio" value="2" required><label class="custom-control-label"
+                    for="id_radio_select_1">2</label></div>
+            <div class="custom-control custom-radio"><input class="custom-control-input is-invalid" id="id_radio_select_2"
+                    name="radio_select" type="radio" value="1000" required><label class="custom-control-label"
+                    for="id_radio_select_2">1000</label>
+            <p class="invalid-feedback" id="error_1_id_radio_select">
+               <strong>This field is required.</strong> 
+            </p>
+            </div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_grouped_checkboxes_failing.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_grouped_checkboxes_failing.html
@@ -1,0 +1,34 @@
+
+<form method="post">
+    <div class="form-group" id="div_id_checkbox_select_multiple"><label class=" requiredField">Checkbox select
+            multiple<span class="asteriskField">*</span></label>
+        <div>
+            <strong>Audio</strong>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input is-invalid"
+                    id="id_checkbox_select_multiple_0_0" name="checkbox_select_multiple" type="checkbox"
+                    value="vinyl"><label class="custom-control-label"
+                    for="id_checkbox_select_multiple_0_0">Vinyl</label></div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input is-invalid"
+                    id="id_checkbox_select_multiple_0_1" name="checkbox_select_multiple" type="checkbox"
+                    value="cd"><label class="custom-control-label" for="id_checkbox_select_multiple_0_1">CD</label>
+            </div>
+            <strong>Video</strong>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input is-invalid"
+                    id="id_checkbox_select_multiple_1_0" name="checkbox_select_multiple" type="checkbox"
+                    value="vhs"><label class="custom-control-label" for="id_checkbox_select_multiple_1_0">VHS
+                    Tape</label></div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input is-invalid"
+                    id="id_checkbox_select_multiple_1_1" name="checkbox_select_multiple" type="checkbox"
+                    value="dvd"><label class="custom-control-label" for="id_checkbox_select_multiple_1_1">DVD</label>
+            </div>
+            <div class="custom-checkbox custom-control"><input class="custom-control-input is-invalid"
+                    id="id_checkbox_select_multiple_2" name="checkbox_select_multiple" type="checkbox"
+                    value="unknown"><label class="custom-control-label"
+                    for="id_checkbox_select_multiple_2">Unknown</label>
+            <p class="invalid-feedback" id="error_1_id_checkbox_select_multiple">
+                <strong>This field is required.</strong>
+            </p>
+            </div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_grouped_radios_failing.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_grouped_radios_failing.html
@@ -1,0 +1,28 @@
+<form method="post">
+    <div class="form-group" id="div_id_radio"><label class=" requiredField" for="id_radio_0">Radio<span
+                class="asteriskField">*</span></label>
+        <div>
+            <strong>Audio</strong>
+            <div class="custom-control custom-radio"><input class="custom-control-input is-invalid" id="id_radio_0_0" name="radio"
+                    required type="radio" value="vinyl"><label class="custom-control-label"
+                    for="id_radio_0_0">Vinyl</label></div>
+            <div class="custom-control custom-radio"><input class="custom-control-input is-invalid" id="id_radio_0_1" name="radio"
+                    required type="radio" value="cd"><label class="custom-control-label" for="id_radio_0_1">CD</label>
+            </div>
+            <strong>Video</strong>
+            <div class="custom-control custom-radio"><input class="custom-control-input is-invalid" id="id_radio_1_0" name="radio"
+                    required type="radio" value="vhs"><label class="custom-control-label" for="id_radio_1_0">VHS
+                    Tape</label></div>
+            <div class="custom-control custom-radio"><input class="custom-control-input is-invalid" id="id_radio_1_1" name="radio"
+                    required type="radio" value="dvd"><label class="custom-control-label" for="id_radio_1_1">DVD</label>
+            </div>
+            <div class="custom-control custom-radio"><input class="custom-control-input is-invalid" id="id_radio_2" name="radio"
+                    required type="radio" value="unknown"><label class="custom-control-label"
+                    for="id_radio_2">Unknown</label>
+            <p class="invalid-feedback" id="error_1_id_radio">
+                <strong>This field is required.</strong>
+            </p>
+            </div>
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -606,6 +606,17 @@ def test_use_custom_control_is_used_in_checkboxes():
         "bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_false.html"
     )
 
+    form = CheckboxesSampleForm({})
+    form.helper = FormHelper()
+    form.helper.layout = Layout(
+        "checkboxes",
+        InlineCheckboxes("alphacheckboxes"),
+        "numeric_multiple_checkboxes",
+    )
+    assert parse_form(form) == parse_expected(
+        "bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_true_failing.html"
+    )
+
 
 @only_bootstrap4
 def test_use_custom_control_is_used_in_radio():
@@ -627,6 +638,15 @@ def test_use_custom_control_is_used_in_radio():
     form.helper.use_custom_control = False
     assert parse_form(form) == parse_expected(
         "bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_false.html"
+    )
+
+    form = SampleForm5({})
+    form.helper = FormHelper()
+    form.helper.layout = Layout(
+        "radio_select",
+    )
+    assert parse_form(form) == parse_expected(
+        "bootstrap4/test_layout/test_use_custom_control_is_used_in_radio_true_failing.html"
     )
 
 

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -546,3 +546,12 @@ class TestBootstrapLayoutObjects:
         assert parse_form(form) == parse_expected("bootstrap4/test_layout_objects/test_grouped_checkboxes.html")
         form.helper.layout = Layout("radio")
         assert parse_form(form) == parse_expected("bootstrap4/test_layout_objects/test_grouped_radios.html")
+
+        form = GroupedChoiceForm({})
+        form.helper = FormHelper()
+        form.helper.layout = Layout("checkbox_select_multiple")
+        assert parse_form(form) == parse_expected(
+            "bootstrap4/test_layout_objects/test_grouped_checkboxes_failing.html"
+        )
+        form.helper.layout = Layout("radio")
+        assert parse_form(form) == parse_expected("bootstrap4/test_layout_objects/test_grouped_radios_failing.html")


### PR DESCRIPTION
This patch fixes the regression I caused when fixing grouped inputs. The error message was being shown below each option. I've also provided an image of what we have now vs the current release to show the previous behaviour being restored. 

This patch
![image](https://user-images.githubusercontent.com/39445562/120604984-746cb180-c445-11eb-9c53-558a3e66d8b3.png)
![image](https://user-images.githubusercontent.com/39445562/120605038-82223700-c445-11eb-964f-26bb9fbe645e.png)

v1.11.2
![image](https://user-images.githubusercontent.com/39445562/120605212-b7c72000-c445-11eb-9af9-c29695fbf65c.png)
(grouped input's don't work here -- that patch is in the next release)