### PR TITLE
Removed `has-danger` from bootstrap4 templates

### DIFF
--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
@@ -1,7 +1,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
             <label {% if field.id_for_label %}for="{{ field.id_for_label }}" {% endif %} class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -1,6 +1,6 @@
 {% load crispy_forms_field %}
 
-<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
+<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
     {% if field.label and form_show_labels %}
         <label for="{{ field.id_for_label }}" class="{% if 'form-horizontal' in form_class %}col-form-label {% endif %}{{ label_class }}{% if field.field.required %} requiredField{% endif %}">
             {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
@@ -3,7 +3,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if 'form-horizontal' in form_class %} row{% endif %}{% if form_group_wrapper_class %} {{ form_group_wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if 'form-horizontal' in form_class %} row{% endif %}{% if form_group_wrapper_class %} {{ form_group_wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label and form_show_labels %}
             <label for="{{ field.id_for_label }}" class="{% if 'form-horizontal' in form_class %}col-form-label {% endif %}{{ label_class }}{% if field.field.required %} requiredField{% endif %}">

--- a/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
@@ -1,7 +1,7 @@
 {% if field.is_hidden %}
     {{ field }}
 {% else %}
-    <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors and field.errors %} has-danger{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
+    <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
 
         {% if field.label %}
             <label {% if field.id_for_label %}for="{{ field.id_for_label }}" {% endif %}class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_true_failing.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_use_custom_control_is_used_in_checkboxes_true_failing.html
@@ -17,7 +17,7 @@
             </div>
         </div>
     </div>
-    <div class="form-group has-danger" id="div_id_alphacheckboxes"><label class=" requiredField">Alphacheckboxes<span
+    <div class="form-group" id="div_id_alphacheckboxes"><label class=" requiredField">Alphacheckboxes<span
                 class="asteriskField">*</span></label>
         <div>
             <div class="custom-checkbox custom-control custom-control-inline"><input class="custom-control-input is-invalid"


### PR DESCRIPTION
`has-danger` is not required for bootstrap4. Here's an image showing that the error inputs still work with this change. 

![image](https://user-images.githubusercontent.com/39445562/120608538-33769c00-c449-11eb-9aa7-0d98d35e623d.png)
