### PR TITLE
Fix css_id for non-ASCII characters - allow unicode in slugify function

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -1,8 +1,8 @@
 from random import randint
 
 from django.template import Template
-from django.template.defaultfilters import slugify
 from django.template.loader import render_to_string
+from django.utils.text import slugify
 
 from .layout import Div, Field, LayoutObject, TemplateNameMixin
 from .utils import TEMPLATE_PACK, flatatt, render_field
@@ -224,7 +224,7 @@ class Container(Div):
         self._active_originally_included = "active" in kwargs
         self.active = kwargs.pop("active", False)
         if not self.css_id:
-            self.css_id = slugify(self.name)
+            self.css_id = slugify(self.name, allow_unicode=True)
 
     def __contains__(self, field_name):
         """

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -11,6 +11,7 @@ from crispy_forms.bootstrap import (
     AccordionGroup,
     Alert,
     AppendedText,
+    Container,
     FieldWithButtons,
     InlineCheckboxes,
     InlineRadios,
@@ -555,3 +556,11 @@ class TestBootstrapLayoutObjects:
         )
         form.helper.layout = Layout("radio")
         assert parse_form(form) == parse_expected("bootstrap4/test_layout_objects/test_grouped_radios_failing.html")
+
+    def test_non_ascii_chars_in_container_name(self):
+        """
+        Test if non-ASCII characters are saved as css_id property.
+        """
+        name = "テスト"
+        test_container = Container(name, "val1", "val2")
+        assert test_container.css_id == name


### PR DESCRIPTION
I've been working on a project that is translated into multiple languages. The bootstrap accordion groups haven't been functioning properly while the container name was translated to Japanese. I realized that the `css_id` of the container is slugified while allowing only ASCII characters.