### PR TITLE
Moved errors to be under the same div as field in PrependedApendedText

### DIFF
--- a/crispy_forms/templates/bootstrap/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap/layout/prepended_appended_text.html
@@ -16,9 +16,9 @@
                 {% if crispy_prepended_text %}<span class="{% if not field|is_select %}add-on{% endif %}{% if active %} active{% endif %}">{{ crispy_prepended_text|safe }}</span>{% endif %}
                 {% crispy_field field %}
                 {% if crispy_appended_text %}<span class="{% if not field|is_select %}add-on{% endif %}{% if active %} active{% endif %}">{{ crispy_appended_text|safe }}</span>{% endif %}
+                
+                {% include 'bootstrap/layout/help_text_and_errors.html' %}
             </div>
-
-            {% include 'bootstrap/layout/help_text_and_errors.html' %}
         </div>
     </div>
 {% endif %}


### PR DESCRIPTION
Currently fields with prepended/appended text have a problem that their errors are not shown.
By the CSSs' rules, the errors are shown when they're the siblings of the fields