### PR TITLE
Updated meta `license-file` in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license-file = LICENSE.txt
+license_file = LICENSE.txt
 
 [isort]
 multi_line_output=3


### PR DESCRIPTION
Use underscore in the setup.cfg key to fix the following warning:

> Usage of dash-separated 'license-file' will not be supported in future versions. Please use the underscore name 'license_file' instead