### PR TITLE
Simplified adding wrapper_class to context when rendering PrependedApppendedText

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -37,10 +37,9 @@ class PrependedAppendedText(Field):
                 "crispy_prepended_text": self.prepended_text,
                 "input_size": self.input_size,
                 "active": getattr(self, "active", False),
+                "wrapper_class": self.wrapper_class,
             }
         )
-        if hasattr(self, "wrapper_class"):
-            extra_context["wrapper_class"] = self.wrapper_class
         template = self.get_template_name(template_pack)
         return render_field(
             self.field,

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -234,7 +234,7 @@ class TestBootstrapLayoutObjects:
         test_form.helper = FormHelper()
         test_form.helper.layout = Layout(
             PrependedAppendedText("email", "@", "gmail.com", wrapper_class="wrapper class"),
-            PrependedAppendedText("email", "@", "gmail.com")
+            PrependedAppendedText("email", "@", "gmail.com"),
         )
         html = render_crispy_form(test_form)
         assert html.count('<div id="div_id_email" class="form-group">') == 1

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -225,9 +225,20 @@ class TestBootstrapLayoutObjects:
                 PrependedAppendedText("email", "@", "gmail.com", css_class="form-control-lg")
             )
             html = render_crispy_form(test_form)
-
             assert 'class="form-control-lg' in html
             assert contains_partial(html, '<span class="input-group-text"/>')
+
+    @only_bootstrap4
+    def test_prepended_wrapper_class(self, settings):
+        test_form = SampleForm()
+        test_form.helper = FormHelper()
+        test_form.helper.layout = Layout(
+            PrependedAppendedText("email", "@", "gmail.com", wrapper_class="wrapper class"),
+            PrependedAppendedText("email", "@", "gmail.com")
+        )
+        html = render_crispy_form(test_form)
+        assert html.count('<div id="div_id_email" class="form-group">') == 1
+        assert html.count('<div id="div_id_email" class="form-group wrapper class">') == 1
 
     @only_bootstrap4
     def test_prepended_appended_text_in_select(self, settings):


### PR DESCRIPTION
`PrependedApppendedText` inherits from `Field` which ensures that the `wrapper_class` attribute is always available. Having an attribute with `None` in the template is fine as it will not get rendered. 

https://github.com/django-crispy-forms/django-crispy-forms/blob/ac9aa0707e7cf87ed196b6f5bd7c72e3f2afc6a6/crispy_forms/layout.py#L443