### PR TITLE
Improved ButtonHolder init signature and doc string

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -139,15 +139,45 @@ class ButtonHolder(LayoutObject):
     """
     Layout object. It wraps fields in a <div class="buttonHolder">
 
-    This is where you should put Layout objects that render to form buttons like Submit.
-    It should only hold `HTML` and `BaseInput` inherited objects.
+    This is where you should put Layout objects that render to form buttons
+    like Submit. It should only hold `HTML` and `BaseInput` inherited objects.
+
+    Attributes:
+        template : str
+            The default template which this Layout Object will be rendered
+            with.
+
+    Args:
+        fields : HTML or BaseInput
+            The layout objects to render within the ButtonHolder.
+
+        css_class : str, optional
+            Additional CSS classes to be included in the
+            button holder `<div>`.
+
+        css_id : str, optional
+            Sets a DOM id for the button holder. .
+
+        template : str, optional
+            Over rides the default template, if provided.
 
     Example::
 
+        # Within a form's `Layout`.
+
         ButtonHolder(
-            HTML(<span style="display: hidden;">Information Saved</span>),
-            Submit('Save', 'Save')
+            HTML('<span style="display: hidden;">Information Saved</span>'),
+            Submit('Save', 'Save'),
+            css_class = "Custom Class",
+            css_id = "ButtonHolderID",
         )
+
+        # Given the above Layout the rendered HTML will be:
+
+        <div id="ButtonHolderID" class="buttonHolder Custom Class">
+            <span style="display: hidden;">Information Saved</span>
+            <input type="submit" name="Save" value="Save" class="btn btn-primary" id="submit-id-save"/>
+        </div>
     """
 
     template = "%s/layout/buttonholder.html"

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -149,11 +149,12 @@ class ButtonHolder(LayoutObject):
 
     Args:
         fields : HTML or BaseInput
-            The layout objects to render within the ButtonHolder.
+            Any number of positional arguments to render within the
+            ButtonHolder.
 
         css_class : str, optional
-            Additional CSS classes to be included in the
-            button holder `<div>`.
+            Additional CSS classes to be included in the button holder
+            `<div>`.
 
         css_id : str, optional
             Sets a DOM id for the button holder.

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -156,7 +156,7 @@ class ButtonHolder(LayoutObject):
             button holder `<div>`.
 
         css_id : str, optional
-            Sets a DOM id for the button holder. .
+            Sets a DOM id for the button holder.
 
         template : str, optional
             Over rides the default template, if provided.

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -159,7 +159,7 @@ class ButtonHolder(LayoutObject):
             Sets a DOM id for the button holder.
 
         template : str, optional
-            Over rides the default template, if provided.
+            Overrides the default template, if provided.
 
     Example::
 

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -152,11 +152,11 @@ class ButtonHolder(LayoutObject):
 
     template = "%s/layout/buttonholder.html"
 
-    def __init__(self, *fields, **kwargs):
+    def __init__(self, *fields, css_class=None, css_id=None, template=None):
         self.fields = list(fields)
-        self.css_class = kwargs.get("css_class", None)
-        self.css_id = kwargs.get("css_id", None)
-        self.template = kwargs.get("template", self.template)
+        self.css_class = css_class
+        self.css_id = css_id
+        self.template = template or self.template
 
     def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
         html = self.get_rendered_fields(form, form_style, context, template_pack, **kwargs)


### PR DESCRIPTION
Most of the `__init__` signatures are `*args, **kwargs`, the method then pops them off as needed. 

I've been thinking what is best practice here as it makes it a little hard to understand what each class accepts. Here is a patch showing one of the more simple cases where I think writing out the kwargs in full will make the package easier to use as folk will get auto complete and so on? 

There's more complex cases, but thought best to start off with the "simple" scenario.

I'm interested in understanding more about conflicting design principles here. The giants who's shoulders we are standing on clearly wrote this for a very good reason! (albeit I wonder if some of this is differences over time, this was originally written about a decade ago!)