### PR TITLE
Multiple Fields

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -821,24 +821,21 @@ class Field(LayoutObject):
     """
 
     template = "%s/field.html"
+    attrs = {}
 
-    def __init__(self, *args, **kwargs):
-        self.fields = list(args)
+    def __init__(self, *fields, css_class=None, wrapper_class=None, template=None, **kwargs):
+        self.fields = list(fields)
+        # Make sure shared state is not edited.
+        self.attrs = self.attrs.copy()
 
-        if not hasattr(self, "attrs"):
-            self.attrs = {}
-        else:
-            # Make sure shared state is not edited.
-            self.attrs = self.attrs.copy()
-
-        if "css_class" in kwargs:
+        if css_class:
             if "class" in self.attrs:
-                self.attrs["class"] += " %s" % kwargs.pop("css_class")
+                self.attrs["class"] += f" {css_class}"
             else:
-                self.attrs["class"] = kwargs.pop("css_class")
+                self.attrs["class"] = css_class
 
-        self.wrapper_class = kwargs.pop("wrapper_class", None)
-        self.template = kwargs.pop("template", self.template)
+        self.wrapper_class = wrapper_class
+        self.template = template or self.template
 
         # We use kwargs as HTML attributes, turning data_id='test' into data-id='test'
         self.attrs.update({k.replace("_", "-"): conditional_escape(v) for k, v in kwargs.items()})
@@ -846,7 +843,7 @@ class Field(LayoutObject):
     def render(self, form, context, template_pack=TEMPLATE_PACK, extra_context=None, **kwargs):
         if extra_context is None:
             extra_context = {}
-        if hasattr(self, "wrapper_class"):
+        if self.wrapper_class:
             extra_context["wrapper_class"] = self.wrapper_class
 
         template = self.get_template_name(template_pack)

--- a/crispy_forms/tests/results/bootstrap3/test_layout/test_multiple_fields.html
+++ b/crispy_forms/tests/results/bootstrap3/test_layout/test_multiple_fields.html
@@ -1,0 +1,20 @@
+<form method="post">
+    <div class="form-group" id="div_id_first_name">
+        <label class="control-label requiredField" for="id_first_name">
+            first name
+            <span class="asteriskField">*</span>
+        </label>
+        <div class="controls">
+            <input class="form-control form-control-lg inputtext textInput textinput" id="id_first_name" maxlength="5" name="first_name" required type="text">
+        </div>
+    </div>
+    <div class="form-group" id="div_id_last_name">
+        <label class="control-label requiredField" for="id_last_name">
+            last name
+            <span class="asteriskField">*</span>
+        </label>
+        <div class="controls">
+            <input class="form-control form-control-lg inputtext textInput textinput" id="id_last_name" maxlength="5" name="last_name" required type="text">
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout/test_multiple_fields.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout/test_multiple_fields.html
@@ -1,0 +1,12 @@
+<form method="post">
+    <div class="form-group" id="div_id_first_name"><label class="requiredField" for="id_first_name">first name<span
+                class="asteriskField">*</span></label>
+        <div><input class="form-control form-control-lg inputtext textInput textinput" id="id_first_name" maxlength="5"
+                name="first_name" required type="text"></div>
+    </div>
+    <div class="form-group" id="div_id_last_name"><label class="requiredField" for="id_last_name">last name<span
+                class="asteriskField">*</span></label>
+        <div><input class="form-control form-control-lg inputtext textInput textinput" id="id_last_name" maxlength="5"
+                name="last_name" required type="text"></div>
+    </div>
+</form>

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -766,6 +766,14 @@ def test_use_custom_control_in_uneditable_select(use_custom_control, expected_ht
     assert parse_form(form) == parse_expected(expected_html)
 
 
+def test_multiple_fields():
+    "Field can accept any number of fields and apply the kwargs to all fields"
+    form = SampleForm()
+    form.helper = FormHelper()
+    form.helper.layout = Layout(Field("first_name", "last_name", css_class="form-control-lg"))
+    assert parse_form(form) == parse_expected("bootstrap4/test_layout/test_multiple_fields.html")
+
+
 @only_bootstrap4
 def test_fundamentals():
     """

--- a/crispy_forms/tests/test_layout.py
+++ b/crispy_forms/tests/test_layout.py
@@ -766,12 +766,13 @@ def test_use_custom_control_in_uneditable_select(use_custom_control, expected_ht
     assert parse_form(form) == parse_expected(expected_html)
 
 
-def test_multiple_fields():
+def test_multiple_fields(settings):
     "Field can accept any number of fields and apply the kwargs to all fields"
     form = SampleForm()
     form.helper = FormHelper()
     form.helper.layout = Layout(Field("first_name", "last_name", css_class="form-control-lg"))
-    assert parse_form(form) == parse_expected("bootstrap4/test_layout/test_multiple_fields.html")
+    template_pack = settings.CRISPY_TEMPLATE_PACK
+    assert parse_form(form) == parse_expected(f"{template_pack}/test_layout/test_multiple_fields.html")
 
 
 @only_bootstrap4


### PR DESCRIPTION
so....

The `Field` docstring says "It contains one field name" yet the `wrap_together` docs say

```
We could do::

    form.helper[0:3].wrap_together(Field, css_class="hello")

We would end up having this layout::

    Layout(
        Field(
            'field_1',
            'field_2',
            'field_3',
            css_class='hello'
        )
    )
```

True enough you can pass multiple fields to `Field` and have the attributes get applied to each of them.

I'm not sure which behaviour is correct.

I guess the best answer is document the current behaviour and give a note about providing something like `id` if you are doing to do this.... 