### PR TITLE
Removed `form_style` attributes and arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
       "passwordinput": "textinput textInput",
   }
   ```
+* The `uni-form` template pack allowed for rendering of templates using a `default` or `inline` layout. As the `uni-form` template
+  pack has been removed support for this has also been removed. This has resulted in the following **BREAKING** changes.
+
+    * The `form_style` attribute of `FormHelper` is removed.
+    * The `form_style` positional argument to `render_field` is removed.
+    * The `form_style` positional argument to the `render` method of all `LayoutObjects` is removed.
+
 * Removed Bootstrap 2 template pack. Bootstrap 3 and 4 support is provided by the core crispy-forms package.
   Support for Bootstrap 5 is provided by a 3rd party package under the `django-crispy-forms` organisation at 
   [crispy-bootstrap5](https://github.com/django-crispy-forms/crispy-bootstrap5).

--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -29,7 +29,7 @@ class PrependedAppendedText(Field):
 
         super().__init__(field, *args, **kwargs)
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, extra_context=None, **kwargs):
+    def render(self, form, context, template_pack=TEMPLATE_PACK, extra_context=None, **kwargs):
         extra_context = extra_context.copy() if extra_context is not None else {}
         extra_context.update(
             {
@@ -44,7 +44,6 @@ class PrependedAppendedText(Field):
         return render_field(
             self.field,
             form,
-            form_style,
             context,
             template=template,
             attrs=self.attrs,
@@ -91,8 +90,8 @@ class FormActions(LayoutObject):
         if "css_class" in self.attrs:
             self.attrs["class"] = self.attrs.pop("css_class")
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
-        html = self.get_rendered_fields(form, form_style, context, template_pack, **kwargs)
+    def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
+        html = self.get_rendered_fields(form, context, template_pack, **kwargs)
         template = self.get_template_name(template_pack)
         context.update({"formactions": self, "fields_output": html})
 
@@ -111,10 +110,8 @@ class InlineCheckboxes(Field):
 
     template = "%s/layout/checkboxselectmultiple_inline.html"
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
-        return super().render(
-            form, form_style, context, template_pack=template_pack, extra_context={"inline_class": "inline"}
-        )
+    def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
+        return super().render(form, context, template_pack=template_pack, extra_context={"inline_class": "inline"})
 
 
 class InlineRadios(Field):
@@ -126,10 +123,8 @@ class InlineRadios(Field):
 
     template = "%s/layout/radioselect_inline.html"
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
-        return super().render(
-            form, form_style, context, template_pack=template_pack, extra_context={"inline_class": "inline"}
-        )
+    def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
+        return super().render(form, context, template_pack=template_pack, extra_context={"inline_class": "inline"})
 
 
 class FieldWithButtons(Div):
@@ -163,14 +158,13 @@ class FieldWithButtons(Div):
         self.input_size = input_size
         super().__init__(*fields, **kwargs)
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, extra_context=None, **kwargs):
+    def render(self, form, context, template_pack=TEMPLATE_PACK, extra_context=None, **kwargs):
         # We first render the buttons
         field_template = self.field_template % template_pack
         buttons = "".join(
             render_field(
                 field,
                 form,
-                form_style,
                 context,
                 field_template,
                 layout_object=self,
@@ -189,7 +183,6 @@ class FieldWithButtons(Div):
             return render_field(
                 self.fields[0][0],
                 form,
-                form_style,
                 context,
                 template,
                 attrs=self.fields[0].attrs,
@@ -198,9 +191,7 @@ class FieldWithButtons(Div):
                 **kwargs,
             )
         else:
-            return render_field(
-                self.fields[0], form, form_style, context, template, extra_context=extra_context, **kwargs
-            )
+            return render_field(self.fields[0], form, context, template, extra_context=extra_context, **kwargs)
 
 
 class StrictButton(TemplateNameMixin):
@@ -228,7 +219,7 @@ class StrictButton(TemplateNameMixin):
 
         self.flat_attrs = flatatt(kwargs)
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
+    def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
         self.content = Template(str(self.content)).render(context)
         template = self.get_template_name(template_pack)
         context.update({"button": self})
@@ -258,13 +249,13 @@ class Container(Div):
         """
         return field_name in map(lambda pointer: pointer[1], self.get_field_names())
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
+    def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
         if self.active:
             if "active" not in self.css_class:
                 self.css_class += " active"
         else:
             self.css_class = self.css_class.replace("active", "")
-        return super().render(form, form_style, context, template_pack)
+        return super().render(form, context, template_pack)
 
 
 class ContainerHolder(Div):
@@ -332,13 +323,13 @@ class TabHolder(ContainerHolder):
 
     template = "%s/layout/tab.html"
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
+    def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
         for tab in self.fields:
             tab.active = False
 
         # Open the group that should be open.
         self.open_target_group_for_form(form)
-        content = self.get_rendered_fields(form, form_style, context, template_pack)
+        content = self.get_rendered_fields(form, context, template_pack)
         links = "".join(tab.render_link(template_pack) for tab in self.fields)
 
         context.update({"tabs": self, "links": links, "content": content})
@@ -381,7 +372,7 @@ class Accordion(ContainerHolder):
         for accordion_group in args:
             accordion_group.data_parent = self.css_id
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
+    def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
         content = ""
 
         # Open the group that should be open.
@@ -389,7 +380,7 @@ class Accordion(ContainerHolder):
 
         for group in self.fields:
             group.data_parent = self.css_id
-            content += render_field(group, form, form_style, context, template_pack=template_pack, **kwargs)
+            content += render_field(group, form, context, template_pack=template_pack, **kwargs)
 
         template = self.get_template_name(template_pack)
         context.update({"accordion": self, "content": content})
@@ -416,7 +407,7 @@ class Alert(Div):
         self.content = content
         self.dismiss = dismiss
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
+    def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
         template = self.get_template_name(template_pack)
         context.update({"alert": self, "content": self.content, "dismiss": self.dismiss})
 
@@ -497,8 +488,8 @@ class Modal(LayoutObject):
 
         self.flat_attrs = flatatt(kwargs)
 
-    def render(self, form, form_style, context, template_pack=TEMPLATE_PACK, **kwargs):
-        fields = self.get_rendered_fields(form, form_style, context, template_pack, **kwargs)
+    def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
+        fields = self.get_rendered_fields(form, context, template_pack, **kwargs)
         template = self.get_template_name(template_pack)
 
         return render_to_string(template, {"modal": self, "fields": fields})

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -145,9 +145,6 @@ class FormHelper(DynamicLayoutHandler):
         **formset_error_title**: If a formset has `non_form_errors` to display, they
             are rendered in a div. You can set title's div with this attribute.
 
-        **form_style**: Uni-form has two built in different form styles. You can choose
-            your favorite. This can be set to "default" or "inline". Defaults to "default".
-
         **include_media**: Whether to automatically include form media. Set to False if
             you want to manually include form media outside the form. Defaults to True.
 
@@ -186,7 +183,7 @@ class FormHelper(DynamicLayoutHandler):
 
     _form_method = "post"
     _form_action = ""
-    _form_style = "default"
+
     form = None
     form_id = ""
     form_class = ""
@@ -248,24 +245,6 @@ class FormHelper(DynamicLayoutHandler):
         self._form_action = action
 
     @property
-    def form_style(self):
-        if self._form_style == "default":
-            return ""
-
-        if self._form_style == "inline":
-            return "inlineLabels"
-
-    @form_style.setter
-    def form_style(self, style):
-        if style.lower() not in ("default", "inline"):
-            raise FormHelpersException(
-                "Only default and inline are valid in the \
-                    form_style helper attribute"
-            )
-
-        self._form_style = style.lower()
-
-    @property
     def help_text_inline(self):
         return self._help_text_inline
 
@@ -297,7 +276,7 @@ class FormHelper(DynamicLayoutHandler):
         form.crispy_field_template = self.field_template
 
         # This renders the specified Layout strictly
-        html = self.layout.render(form, self.form_style, context, template_pack=template_pack)
+        html = self.layout.render(form, context, template_pack=template_pack)
 
         # Rendering some extra fields if specified
         if self.render_unmentioned_fields or self.render_hidden_fields or self.render_required_fields:
@@ -309,7 +288,7 @@ class FormHelper(DynamicLayoutHandler):
                     or (self.render_hidden_fields and form.fields[field].widget.is_hidden)
                     or (self.render_required_fields and form.fields[field].widget.is_required)
                 ):
-                    html += render_field(field, form, self.form_style, context, template_pack=template_pack)
+                    html += render_field(field, form, context, template_pack=template_pack)
 
         return mark_safe(html)
 
@@ -325,7 +304,6 @@ class FormHelper(DynamicLayoutHandler):
             "form_method": self.form_method.strip(),
             "form_show_errors": self.form_show_errors,
             "form_show_labels": self.form_show_labels,
-            "form_style": self.form_style.strip(),
             "form_tag": self.form_tag,
             "help_text_inline": self.help_text_inline,
             "html5_required": self.html5_required,

--- a/crispy_forms/templates/bootstrap3/layout/fieldset.html
+++ b/crispy_forms/templates/bootstrap3/layout/fieldset.html
@@ -1,5 +1,5 @@
 <fieldset {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %} 
-    {% if fieldset.css_class or form_style %}class="{{ fieldset.css_class }} {{ form_style }}"{% endif %}
+    {% if fieldset.css_class %}class="{{ fieldset.css_class }}"{% endif %}
     {{ fieldset.flat_attrs|safe }}>
     {% if legend %}<legend>{{ legend|safe }}</legend>{% endif %}
     {{ fields|safe }} 

--- a/crispy_forms/templates/bootstrap4/layout/fieldset.html
+++ b/crispy_forms/templates/bootstrap4/layout/fieldset.html
@@ -1,5 +1,5 @@
 <fieldset {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %} 
-    {% if fieldset.css_class or form_style %}class="{{ fieldset.css_class }} {{ form_style }}"{% endif %}
+    {% if fieldset.css_class%}class="{{ fieldset.css_class }}"{% endif %}
     {{ fieldset.flat_attrs|safe }}>
     {% if legend %}<legend>{{ legend|safe }}</legend>{% endif %}
     {{ fields|safe }} 

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -158,7 +158,6 @@ class BasicNode(template.Node):
             "%s_class" % form_type: attrs["attrs"].get("class", ""),
             "%s_id" % form_type: attrs["attrs"].get("id", ""),
             "%s_method" % form_type: attrs.get("form_method", "post"),
-            "%s_style" % form_type: attrs.get("form_style", None),
             "%s_tag" % form_type: attrs.get("form_tag", True),
             "disable_csrf": attrs.get("disable_csrf", False),
             "error_text_inline": attrs.get("error_text_inline", True),

--- a/crispy_forms/tests/test_utils.py
+++ b/crispy_forms/tests/test_utils.py
@@ -24,7 +24,7 @@ def test_list_difference():
 
 
 def test_render_field_with_none_field():
-    rendered = render_field(field=None, form=None, form_style=None, context=None)
+    rendered = render_field(field=None, form=None, context=None)
     assert rendered == ""
 
 

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -28,7 +28,6 @@ def default_field_template(template_pack=TEMPLATE_PACK):
 def render_field(  # noqa: C901
     field,
     form,
-    form_style,
     context,
     template=None,
     labelclass=None,
@@ -47,7 +46,6 @@ def render_field(  # noqa: C901
         The field is added to a list that the form holds called `rendered_fields`
         to avoid double rendering fields.
     :param form: The form/formset to which that field belongs to.
-    :param form_style: A way to pass style name to the CSS framework used.
     :template: Template used for rendering the field.
     :layout_object: If passed, it points to the Layout object that is being rendered.
         We use it to store its bound fields in a list called `layout_object.bound_fields`
@@ -63,7 +61,7 @@ def render_field(  # noqa: C901
         FAIL_SILENTLY = getattr(settings, "CRISPY_FAIL_SILENTLY", True)
 
         if hasattr(field, "render"):
-            return field.render(form, form_style, context, template_pack=template_pack)
+            return field.render(form, context, template_pack=template_pack)
 
         try:
             # Injecting HTML attributes into field's widget, Django handles rendering these

--- a/docs/form_helper.rst
+++ b/docs/form_helper.rst
@@ -80,9 +80,6 @@ Helper attributes you can set
 **formset_error_title**
     If you are rendering a formset using ``{% crispy %}`` tag and it has ``non_form_errors`` to display, they are rendered in a div. You can set the title of the div with this attribute. Example: “Formset Errors”.
 
-**form_style = 'default'**
-    Helper attribute for uni_form template pack. Uni-form has two different form styles built-in. You can choose which one to use, setting this variable to ``default`` or ``inline``.
-
 **form_show_errors = True**
     Default set to ``True``. It decides whether to render or not form errors. If set to ``False``, form.errors will not be visible even if they happen. You have to manually render them customizing your template. This allows you to customize error output.
 

--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -380,7 +380,7 @@ Creating your own layout objects
 
 The :ref:`layout objects` bundled with django-crispy-forms are a set of the most seen components that build a form. You will probably be able to do anything you need combining them. Anyway, you may want to create your own components, for doing that, you will need a good grasp of django-crispy-forms. Every layout object must have a method called ``render``. Its prototype should be::
 
-    def render(self, form, form_style, context):
+    def render(self, form, context):
 
 The official layout objects live in ``layout.py`` and ``bootstrap.py``, you may want to have a look at them to fully understand how to proceed. But in general terms, a layout object is a template rendered with some parameters passed.
 


### PR DESCRIPTION
`form_style` eased customisation of the `uni-form` template pack. As the `uni-form` template pack is now removed the API can be simplified by removing this now unused feature.

I think this is the right thing to do as `form_style` was a feature of `uni-form` as it helped to add the `inlineLabels` class.

For Bootstrap template packs we have `InlineRadios`, `InlineCheckboxes` and `InlineField` layout objects. 

However, as this was a positional argument to some of the core methods this will be a **BREAKING** change to folk using those methods. For example if you are using ajax/htmx to render a bit of your form inside of a view. The example in the docs uses key word arguments so doesn't encounter the issue. 

I *think* the notes in the changelog are sufficient to explain how you'd need to update your code (i.e. remove the argument) but really happy to hear other thoughts. 