### PR TITLE
Removed `html5_required` from `FormHelper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   Support for Bootstrap 5 is provided by a 3rd party package under the `django-crispy-forms` organisation at 
   [crispy-bootstrap5](https://github.com/django-crispy-forms/crispy-bootstrap5).
 * Default template pack is now `bootstrap4` if the `CRISPY_TEMPLATE_PACK` setting is not provided.
+* The `html5_required` attribute of `FormHelper` is removed. In all supported versions of Django the `required` attribute is provided by the core `forms` module. 
 
 ## 1.14.0 (2022-01-22)
 * Added support for Python 3.10

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -201,7 +201,6 @@ class FormHelper(DynamicLayoutHandler):
     render_required_fields = False
     _help_text_inline = False
     _error_text_inline = True
-    html5_required = False
     form_show_labels = True
     template = None
     field_template = None
@@ -328,7 +327,6 @@ class FormHelper(DynamicLayoutHandler):
             "form_style": self.form_style.strip(),
             "form_tag": self.form_tag,
             "help_text_inline": self.help_text_inline,
-            "html5_required": self.html5_required,
             "include_media": self.include_media,
             "label_class": self.label_class,
             "use_custom_control": self.use_custom_control,

--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -170,7 +170,6 @@ class BasicNode(template.Node):
             "form_show_labels": attrs.get("form_show_labels", True),
             "formset_error_title": attrs.get("formset_error_title", None),
             "help_text_inline": attrs.get("help_text_inline", False),
-            "html5_required": attrs.get("html5_required", False),
             "include_media": attrs.get("include_media", True),
             "inputs": attrs.get("inputs", []),
             "is_formset": is_formset,

--- a/docs/form_helper.rst
+++ b/docs/form_helper.rst
@@ -110,9 +110,6 @@ There are currently some helper attributes that only have functionality for a sp
 **error_text_inline = True**
     Sets whether to render error messages inline or block. If set to ``True`` errors will be rendered using ``help-inline`` class, otherwise using ``help-block``. By default error messages are rendered in inline mode.
 
-**html5_required = False**
-    When set to ``True`` all required fields inputs will be rendered with HTML5 ``required=required`` attribute.
-
 **form_show_labels = True**
     Default set to ``True``. Determines whether or not to render the form's field labels.
 


### PR DESCRIPTION
The `required` attribute is added by Django core in all currently
supported versions.