### PR TITLE
Added FormActions tests

### DIFF
--- a/crispy_forms/tests/results/bootstrap3/test_layout_objects/test_FormActions.html
+++ b/crispy_forms/tests/results/bootstrap3/test_layout_objects/test_FormActions.html
@@ -1,0 +1,8 @@
+<form method="post">
+    <div class="custom-class" class="form-group" css-id="css-id" data="safe <>& data">
+        <div class="controls field-class">
+            <span style="display: hidden;">Information Saved</span>
+            <input class="btn btn-primary btn-primary" id="submit-id-save" name="Save" type="submit" value="Save">
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_FormActions.html
+++ b/crispy_forms/tests/results/bootstrap4/test_layout_objects/test_FormActions.html
@@ -1,0 +1,8 @@
+<form method="post">
+    <div class="custom-class" class="form-group" css-id="css-id" data="safe <>& data">
+        <div class="field-class">
+            <span style="display: hidden;">Information Saved</span>
+            <input class="btn btn-primary btn-primary" id="submit-id-save" name="Save" type="submit" value="Save">
+        </div>
+    </div>
+</form>

--- a/crispy_forms/tests/test_layout_objects.py
+++ b/crispy_forms/tests/test_layout_objects.py
@@ -12,6 +12,7 @@ from crispy_forms.bootstrap import (
     AppendedText,
     Container,
     FieldWithButtons,
+    FormActions,
     InlineCheckboxes,
     InlineRadios,
     Modal,
@@ -22,7 +23,7 @@ from crispy_forms.bootstrap import (
     TabHolder,
 )
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import HTML, Field, Layout, MultiWidgetField
+from crispy_forms.layout import HTML, Field, Layout, MultiWidgetField, Submit
 from crispy_forms.tests.utils import contains_partial, parse_expected, parse_form
 from crispy_forms.utils import render_crispy_form
 
@@ -582,3 +583,20 @@ class TestBootstrapLayoutObjects:
         )
 
         assert parse_form(form) == parse_expected("bootstrap4/test_layout_objects/bootstrap_modal_with_kwargs.html")
+
+    def test_FormActions(self, settings):
+        form = SampleForm()
+        form.helper = FormHelper()
+        form.helper.field_class = "field-class"
+        form.helper.layout = Layout(
+            FormActions(
+                HTML('<span style="display: hidden;">Information Saved</span>'),
+                Submit("Save", "Save", css_class="btn-primary"),
+                css_class="custom-class",
+                css_id="css-id",
+                data="safe <>& data",
+            ),
+        )
+
+        template_pack = settings.CRISPY_TEMPLATE_PACK
+        assert parse_form(form) == parse_expected(f"{template_pack}/test_layout_objects/test_FormActions.html")


### PR DESCRIPTION
Some of this is a bit surprising, e.g. `class="custom-class" class="form-group"`

This object works a little differently to many of the other classes. I think we should standardise. In particular the `__init__()` should allow `css_class` and `css_id` to be passes in and added more appropriately. 


EDIT:

Adding tests now to demonstrate current behaviour. I'll then change it in a separate PR. 