### PR TITLE
Improved performance of get_layout_objects().

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -78,9 +78,10 @@ class LayoutObject(TemplateNameMixin):
         elif index is None:
             index = []
 
+        str_class = len(LayoutClasses) == 1 and LayoutClasses[0] == str
         for i, layout_object in enumerate(self.fields):
             if isinstance(layout_object, LayoutClasses):
-                if len(LayoutClasses) == 1 and LayoutClasses[0] == str:
+                if str_class:
                     pointers.append([index + [i], layout_object])
                 else:
                     pointers.append([index + [i], layout_object.__class__.__name__.lower()])


### PR DESCRIPTION
We can avoid a `len()` call, a lookup and a type comparison for each field by moving this line outside of the loop. 

Not sure about the name `str_class` as the variable name, but I'm I guess it'll do. 