### PR TITLE
Dropped Django 2.2 support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * The `html5_required` attribute of `FormHelper` is removed. In all supported versions of Django the `required` attribute is provided by the core `forms` module. 
 * The `FormActions` layout object learnt a `css_id` kwarg to add an `id` to the rendered `<div>`
 * The `flat_attrs()` method of `FormActions` is removed. Attributes provided by `**kwargs` are now passed via the `flat_attrs` function during `__init__()` instead of with each call of `render()`.
+* Dropped support for Django 2.2.
 
 ## 1.14.0 (2022-01-22)
 * Added support for Python 3.10

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ django-crispy-forms
 
 The best way to have Django_ DRY forms. Build programmatic reusable layouts out of components, having full control of the rendered HTML without writing HTML in templates. All this without breaking the standard way of doing things in Django, so it plays nice with any other form application.
 
-`django-crispy-forms` supports Django 2.2, 3.2 and 4.0 with Python 3.7+.
+`django-crispy-forms` supports Django 3.2 and 4.0 with Python 3.7+.
 
 **Note: Django 4.0 requires version 1.13+.**
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -51,4 +51,5 @@ setup(
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.7",
+    install_requires="django>=3.2",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
 envlist =
-    {py37,py38,py39}-django{22},
     {py37,py38,py39,py310}-django{32},
     {py38,py39,py310}-django{40,-latest},
     lint
 
 [testenv]
 deps =
-    django22: django>=2.2,<2.3
     django32: django>=3.2,<3.3
     django40: django>=4.0a,<4.1
     django-latest: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
Django 2.2 support ends in April. It's very unlikely I'll be able to get a release out by then. 

Django 2.2 had a behaviour where the html comparisons were different for whitespace compared to 3.2+ and greater. 

It would greatly simplify working on tests if Django 2.2 was no longer supported. 
﻿
