### PR TITLE
Link to crispy-bulma template pack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,10 +25,11 @@ The application mainly provides:
 * A filter named ``|crispy`` that will render elegant div based forms. Think of it as the built-in methods: ``as_table``, ``as_ul`` and ``as_p``. You cannot tune up the output, but it is easy to start using it.
 * A tag named ``{% crispy %}`` that will render a form based on your configuration and specific layout setup. This gives you amazing power without much hassle, helping you save tons of time.
 
-Django-crispy-forms supports several frontend frameworks, such as Twitter `Bootstrap`_ (versions 2, 3, and 4), `tailwind`_ and Foundation. You can also easily adapt your custom company's one, creating your own, `see the docs`_ for more information. You can easily switch among them using ``CRISPY_TEMPLATE_PACK`` setting variable.
+Django-crispy-forms supports several frontend frameworks, such as Twitter `Bootstrap`_ (versions 2, 3, and 4), `tailwind`_, `Bulma`_ and Foundation. You can also easily adapt your custom company's one, creating your own, `see the docs`_ for more information. You can easily switch among them using ``CRISPY_TEMPLATE_PACK`` setting variable.
 
 .. _`tailwind`: https://github.com/django-crispy-forms/crispy-tailwind
 .. _`Bootstrap`: https://getbootstrap.com
+.. _`Bulma`: https://github.com/ckrybus/crispy-bulma
 .. _`see the docs`: https://django-crispy-forms.readthedocs.io
 
 Authors

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -46,6 +46,7 @@ In addition the following template packs are available through separately mainta
 * ``foundation`` `Foundation`_ In the creator's words, "The most advanced responsive front-end framework in the world." This template pack is available through `crispy-forms-foundation`_
 * ``tailwind`` `Tailwind`_ A utility first framework. This template pack is available through `crispy-tailwind`_
 * ``Bootstrap 5`` Support for newer versions of Bootstrap will be in separate template packs. This starts with version 5 and is available through `crispy-bootstrap5`_
+* ``Bulma`` `Bulma`_: the modern CSS framework that just works. This template pack is available through `crispy-bulma`_
 
 If your form CSS framework is not supported and it's open source, you can create a ``crispy-forms-templatePackName`` project. Please let me know, so I can link to it. Documentation on :ref:`template_packs` is provided.
 
@@ -56,11 +57,13 @@ You can set your default template pack for your project using the ``CRISPY_TEMPL
 Please check the documentation of your template pack package for the correct value of the ``CRISPY_TEMPLATE_PACK`` setting (there are packages which provide more than one template pack).
 
 .. _`Bootstrap`: https://getbootstrap.com
+.. _`Bulma`: https://bulma.io
 .. _`Foundation`: https://get.foundation
 .. _`crispy-forms-foundation`: https://github.com/sveetch/crispy-forms-foundation
 .. _`Tailwind`: https://tailwindcss.com
 .. _`crispy-tailwind`: https://github.com/django-crispy-forms/crispy-tailwind
 .. _`crispy-bootstrap5`: https://github.com/django-crispy-forms/crispy-bootstrap5
+.. _`crispy-bulma`: https://github.com/ckrybus/crispy-bulma
 
 Setting media files
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Hi,

I would like to add a link to [crispy-bulma](https://github.com/ckrybus/crispy-bulma) template pack. 

I've been using django-crispy-forms with bootstrap since 2013 and [django-crispy-bulma](https://github.com/python-discord/django-crispy-bulma) since 2019, but unfortunately django-crispy-bulma has been archived a while ago :-(

Since I'm using it in multiple projects in production I've decided to revive it and maintain it over the long term.
It's still a work in progress, but it is almost feature complete and hopefully it will get even better in the next few weeks.