### PR TITLE
Fixes #1115 -- Documentation for latest and stable in readthedocs is not updated

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 Django
-Sphinx
+Sphinx>=5
 sphinx_rtd_theme
 numpydoc


### PR DESCRIPTION
Hopefully upgrading the version of Sphinx used at RTD should fix this. 

See:

https://readthedocs.org/projects/django-crispy-forms/builds/15204766/
https://github.com/sphinx-doc/sphinx/issues/9727#issuecomment-953099565
