### PR TITLE
Removed `|safe` filter from form labels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG for django-crispy-forms
 
 ## 2.0 (tbc)
+* Removed `|safe` filter from field labels. If you with to retain rendering html in your 
+  `<label>` mark it as safe using 
+  [`mark_safe()`](https://docs.djangoproject.com/en/4.0/ref/utils/#django.utils.safestring.mark_safe) 
+  in your project. Refs #296. 
+
 * Removed uni-form template pack. Uni-Form specific classes previously added to every template pack e.g. `textInput` and are now removed.
   If you require these classes then the previous behaviour can be restored by adding the following to [CRISPY_CLASS_CONVERTERS](https://django-crispy-forms.readthedocs.io/en/latest/crispy_tag_forms.html#change-crispy-forms-input-default-classes) in your settings file.
 

--- a/crispy_forms/templates/bootstrap3/field.html
+++ b/crispy_forms/templates/bootstrap3/field.html
@@ -12,7 +12,7 @@
     <{% if tag %}{{ tag }}{% else %}div{% endif %} id="div_{{ field.auto_id }}" {% if not field|is_checkbox %}class="form-group{% else %}class="checkbox{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if form_show_errors%}{% if field.errors %} has-error{% endif %}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
         {% if field.label and not field|is_checkbox and form_show_labels %}
             <label {% if field.id_for_label and not field|is_radioselect %}for="{{ field.id_for_label }}" {% endif %} class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
-                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}
 
@@ -28,7 +28,7 @@
             {% if field|is_checkbox and form_show_labels %}
                 <label for="{{ field.id_for_label }}" class="{% if field.field.required %} requiredField{% endif %}">
                     {% crispy_field field %}
-                    {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                    {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
                 </label>
                 {% include 'bootstrap3/layout/help_text_and_errors.html' %}
             {% else %}

--- a/crispy_forms/templates/bootstrap3/layout/checkboxselectmultiple_inline.html
+++ b/crispy_forms/templates/bootstrap3/layout/checkboxselectmultiple_inline.html
@@ -5,7 +5,7 @@
 
         {% if field.label %}
             <label for="{{ field.auto_id }}"  class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
-                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}
 

--- a/crispy_forms/templates/bootstrap3/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap3/layout/field_with_buttons.html
@@ -3,7 +3,7 @@
 <div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
     {% if field.label and form_show_labels %}
         <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
-            {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
         </label>
     {% endif %}
 

--- a/crispy_forms/templates/bootstrap3/layout/inline_field.html
+++ b/crispy_forms/templates/bootstrap3/layout/inline_field.html
@@ -7,13 +7,13 @@
         <div id="div_{{ field.auto_id }}" class="checkbox{% if wrapper_class %} {{ wrapper_class }}{% endif %}">
             <label for="{{ field.id_for_label }}" class="{% if field.field.required %} requiredField{% endif %}">
                 {% crispy_field field 'class' 'checkbox' %}
-                {{ field.label|safe }}
+                {{ field.label }}
             </label>
         </div>
     {% else %}
         <div id="div_{{ field.auto_id }}" class="form-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}">
             <label for="{{ field.id_for_label }}" class="sr-only{% if field.field.required %} requiredField{% endif %}">
-                {{ field.label|safe }}
+                {{ field.label }}
             </label>
             {% crispy_field field 'placeholder' field.label %}
         </div>

--- a/crispy_forms/templates/bootstrap3/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap3/layout/prepended_appended_text.html
@@ -7,7 +7,7 @@
 
         {% if field.label and form_show_labels %}
             <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
-                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}
 

--- a/crispy_forms/templates/bootstrap3/layout/radioselect_inline.html
+++ b/crispy_forms/templates/bootstrap3/layout/radioselect_inline.html
@@ -5,7 +5,7 @@
 
         {% if field.label %}
             <label for="{{ field.auto_id }}"  class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
-                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}
 

--- a/crispy_forms/templates/bootstrap3/layout/uneditable_input.html
+++ b/crispy_forms/templates/bootstrap3/layout/uneditable_input.html
@@ -2,7 +2,7 @@
 
 
 <div id="div_{{ field.auto_id }}" class="form-group{% if form_show_errors and field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
-    <label class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}</label>
+    <label class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">{{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}</label>
     <div class="controls {{ field_class }}">
         {% crispy_field field 'disabled' 'disabled' %}
         {% include 'bootstrap3/layout/help_text.html' %}

--- a/crispy_forms/templates/bootstrap3/table_inline_formset.html
+++ b/crispy_forms/templates/bootstrap3/table_inline_formset.html
@@ -22,7 +22,7 @@
                     {% for field in formset.forms.0 %}
                         {% if field.label and not field.is_hidden %}
                             <th for="{{ field.auto_id }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
-                                {{ field.label|safe }}{% if field.field.required and not field|is_checkbox %}<span class="asteriskField">*</span>{% endif %}
+                                {{ field.label }}{% if field.field.required and not field|is_checkbox %}<span class="asteriskField">*</span>{% endif %}
                             </th>
                         {% endif %}
                     {% endfor %}

--- a/crispy_forms/templates/bootstrap4/field.html
+++ b/crispy_forms/templates/bootstrap4/field.html
@@ -13,7 +13,7 @@
         {% if field.label and not field|is_checkbox and form_show_labels %}
         {# not field|is_radioselect in row below can be removed once Django 3.2 is no longer supported #}    
         <label {% if field.id_for_label and not field|is_radioselect %}for="{{ field.id_for_label }}" {% endif %}class="{% if 'form-horizontal' in form_class %}col-form-label {% endif %}{{ label_class }}{% if field.field.required %} requiredField{% endif %}">
-                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}
 
@@ -41,7 +41,7 @@
                     {% endif %}
                 {% endif %}
                 <label for="{{ field.id_for_label }}" class="{%if use_custom_control%}custom-control-label{% else %}form-check-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
-                    {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                    {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
                 </label>
                 {% include 'bootstrap4/layout/help_text_and_errors.html' %}
             {% elif field|is_file and use_custom_control  %}

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple_inline.html
@@ -5,7 +5,7 @@
 
         {% if field.label %}
             <label {% if field.id_for_label %}for="{{ field.id_for_label }}" {% endif %} class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
-                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}
 

--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -3,7 +3,7 @@
 <div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
     {% if field.label and form_show_labels %}
         <label for="{{ field.id_for_label }}" class="{% if 'form-horizontal' in form_class %}col-form-label {% endif %}{{ label_class }}{% if field.field.required %} requiredField{% endif %}">
-            {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
         </label>
     {% endif %}
 

--- a/crispy_forms/templates/bootstrap4/layout/inline_field.html
+++ b/crispy_forms/templates/bootstrap4/layout/inline_field.html
@@ -11,13 +11,13 @@
                 {% else %}
                     {% crispy_field field 'class' 'form-check-input' %}
                 {% endif %}
-                {{ field.label|safe }}
+                {{ field.label }}
             </label>
         </div>
     {% else %}
         <div id="div_{{ field.auto_id }}" class="input-group{% if wrapper_class %} {{ wrapper_class }}{% endif %}">
             <label for="{{ field.id_for_label }}" class="sr-only{% if field.field.required %} requiredField{% endif %}">
-                {{ field.label|safe }}
+                {{ field.label }}
             </label>
             {% if field.errors %}
                 {% crispy_field field 'placeholder' field.label 'class' 'form-control is-invalid' %}

--- a/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
+++ b/crispy_forms/templates/bootstrap4/layout/prepended_appended_text.html
@@ -7,7 +7,7 @@
 
         {% if field.label and form_show_labels %}
             <label for="{{ field.id_for_label }}" class="{% if 'form-horizontal' in form_class %}col-form-label {% endif %}{{ label_class }}{% if field.field.required %} requiredField{% endif %}">
-                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}
 

--- a/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect_inline.html
@@ -5,7 +5,7 @@
 
         {% if field.label %}
             <label {% if field.id_for_label %}for="{{ field.id_for_label }}" {% endif %}class="{{ label_class }}{% if not inline_class %} col-form-label{% endif %}{% if field.field.required %} requiredField{% endif %}">
-                {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
             </label>
         {% endif %}
 

--- a/crispy_forms/templates/bootstrap4/layout/uneditable_input.html
+++ b/crispy_forms/templates/bootstrap4/layout/uneditable_input.html
@@ -1,6 +1,6 @@
 {% load crispy_forms_field %}
 <div id="div_{{ field.auto_id }}" class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if form_show_errors and field.errors %} error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}">
-    <label class="{% if 'form-horizontal' in form_class %}col-form-label {% endif %}{{ label_class }}{% if field.field.required %} requiredField{% endif %}">{{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}</label>
+    <label class="{% if 'form-horizontal' in form_class %}col-form-label {% endif %}{{ label_class }}{% if field.field.required %} requiredField{% endif %}">{{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}</label>
     <div class="{{ field_class }}">
         {% if field|is_select and use_custom_control %}
             {% crispy_field field 'class' 'custom-select' 'disabled' 'disabled' %}

--- a/crispy_forms/templates/bootstrap4/table_inline_formset.html
+++ b/crispy_forms/templates/bootstrap4/table_inline_formset.html
@@ -22,7 +22,7 @@
                     {% for field in formset.forms.0 %}
                         {% if field.label and not field.is_hidden %}
                             <th for="{{ field.auto_id }}" class="col-form-label {% if field.field.required %}requiredField{% endif %}">
-                                {{ field.label|safe }}{% if field.field.required and not field|is_checkbox %}<span class="asteriskField">*</span>{% endif %}
+                                {{ field.label }}{% if field.field.required and not field|is_checkbox %}<span class="asteriskField">*</span>{% endif %}
                             </th>
                         {% endif %}
                     {% endfor %}

--- a/docs/form_helper.rst
+++ b/docs/form_helper.rst
@@ -187,13 +187,13 @@ When we find where labels get rendered, this chunk of code to be more precise::
 
     {% if field.label and not field|is_checkbox and form_show_labels %}
         <label for="{{ field.id_for_label }}" class="control-label {% if field.field.required %}requiredField{% endif %}">
-            {{ field.label|safe }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+            {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
         </label>
     {% endif %}
 
 The line that we would change would end up like this::
 
-    {% if not labels_uppercase %}{{ field.label|safe }}{% else %}{{ field.label|safe|upper }}{% endif %}{% if field.field.required %}
+    {% if not labels_uppercase %}{{ field.label }}{% else %}{{ field.label|upper }}{% endif %}{% if field.field.required %}
 
 Now we only need to override field template, for that you may want to check section :ref:`override templates`.
 


### PR DESCRIPTION
Using `|safe` in templates is not prefered as it _can_ be a security risk. Use `mark_safe()` in project code to retain previous behaviour. Refs #296.