### PR TITLE
Removed `|safe` from `flat_attrs`

### DIFF
--- a/crispy_forms/templates/bootstrap3/layout/baseinput.html
+++ b/crispy_forms/templates/bootstrap3/layout/baseinput.html
@@ -5,5 +5,5 @@
         class="{{ input.field_classes }}"
         id="{{ input.id }}"
     {% endif %}
-    {{ input.flat_attrs|safe }}
+    {{ input.flat_attrs }}
     />

--- a/crispy_forms/templates/bootstrap3/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap3/layout/checkboxselectmultiple.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<div class="controls {{ field_class }}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+<div class="controls {{ field_class }}"{% if flat_attrs %} {{ flat_attrs }}{% endif %}>
     {% include 'bootstrap3/layout/field_errors_block.html' %}
 
     {% for group, options, index in field|optgroups %}

--- a/crispy_forms/templates/bootstrap3/layout/column.html
+++ b/crispy_forms/templates/bootstrap3/layout/column.html
@@ -1,3 +1,3 @@
-<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="formColumn {{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="formColumn {{ div.css_class|default:'' }}" {{ div.flat_attrs }}>
         {{ fields|safe }}
 </div>

--- a/crispy_forms/templates/bootstrap3/layout/div.html
+++ b/crispy_forms/templates/bootstrap3/layout/div.html
@@ -1,4 +1,4 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
-    {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
+    {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs }}>
         {{ fields|safe }}
 </div>

--- a/crispy_forms/templates/bootstrap3/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap3/layout/field_with_buttons.html
@@ -1,6 +1,6 @@
 {% load crispy_forms_field %}
 
-<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
+<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if form_show_errors and field.errors %} has-error{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs }}>
     {% if field.label and form_show_labels %}
         <label for="{{ field.id_for_label }}" class="control-label {{ label_class }}{% if field.field.required %} requiredField{% endif %}">
             {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}

--- a/crispy_forms/templates/bootstrap3/layout/fieldset.html
+++ b/crispy_forms/templates/bootstrap3/layout/fieldset.html
@@ -1,6 +1,6 @@
 <fieldset {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %} 
     {% if fieldset.css_class %}class="{{ fieldset.css_class }}"{% endif %}
-    {{ fieldset.flat_attrs|safe }}>
+    {{ fieldset.flat_attrs }}>
     {% if legend %}<legend>{{ legend|safe }}</legend>{% endif %}
     {{ fields|safe }} 
 </fieldset>

--- a/crispy_forms/templates/bootstrap3/layout/modal.html
+++ b/crispy_forms/templates/bootstrap3/layout/modal.html
@@ -1,4 +1,4 @@
-<div id="{{ modal.css_id }}" class="modal fade {{ modal.css_class }}" {{ modal.flat_attrs|safe }}>
+<div id="{{ modal.css_id }}" class="modal fade {{ modal.css_class }}" {{ modal.flat_attrs }}>
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header">

--- a/crispy_forms/templates/bootstrap3/layout/multifield.html
+++ b/crispy_forms/templates/bootstrap3/layout/multifield.html
@@ -1,6 +1,6 @@
 <div {% if multifield.css_id or errors %}id="{{ multifield.css_id }}"{% endif %}
     {% if multifield.css_class %}class="{{ multifield.css_class }}"{% endif %}
-    {{ multifield.flat_attrs|safe }}>
+    {{ multifield.flat_attrs }}>
 
     {% if form_show_errors %}
         <div class="alert alert-danger" role="alert">

--- a/crispy_forms/templates/bootstrap3/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap3/layout/radioselect.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<div class="controls {{ field_class }}"{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+<div class="controls {{ field_class }}"{% if flat_attrs %} {{ flat_attrs }}{% endif %}>
     {% include 'bootstrap3/layout/field_errors_block.html' %}
 
     {% for group, options, index in field|optgroups %}

--- a/crispy_forms/templates/bootstrap3/layout/row.html
+++ b/crispy_forms/templates/bootstrap3/layout/row.html
@@ -1,3 +1,3 @@
-<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="row {{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="row {{ div.css_class|default:'' }}" {{ div.flat_attrs }}>
         {{ fields|safe }}
 </div>

--- a/crispy_forms/templates/bootstrap3/table_inline_formset.html
+++ b/crispy_forms/templates/bootstrap3/table_inline_formset.html
@@ -4,7 +4,7 @@
 
 {% specialspaceless %}
 {% if formset_tag %}
-<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
+<form {{ flat_attrs }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
 {% endif %}
     {% if formset_method|lower == 'post' and not disable_csrf %}
         {% csrf_token %}

--- a/crispy_forms/templates/bootstrap3/whole_uni_form.html
+++ b/crispy_forms/templates/bootstrap3/whole_uni_form.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_utils %}
 
 {% specialspaceless %}
-{% if form_tag %}<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>{% endif %}
+{% if form_tag %}<form {{ flat_attrs }} method="{{ form_method }}" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>{% endif %}
     {% if form_method|lower == 'post' and not disable_csrf %}
         {% csrf_token %}
     {% endif %}

--- a/crispy_forms/templates/bootstrap3/whole_uni_formset.html
+++ b/crispy_forms/templates/bootstrap3/whole_uni_formset.html
@@ -3,7 +3,7 @@
 
 {% specialspaceless %}
 {% if formset_tag %}
-<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
+<form {{ flat_attrs }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
 {% endif %}
     {% if formset_method|lower == 'post' and not disable_csrf %}
         {% csrf_token %}

--- a/crispy_forms/templates/bootstrap4/layout/baseinput.html
+++ b/crispy_forms/templates/bootstrap4/layout/baseinput.html
@@ -5,5 +5,5 @@
         class="{{ input.field_classes }}"
         id="{{ input.id }}"
     {% endif %}
-    {{ input.flat_attrs|safe }}
+    {{ input.flat_attrs }}
     />

--- a/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
+++ b/crispy_forms/templates/bootstrap4/layout/checkboxselectmultiple.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<div {% if field_class %}class="{{ field_class }}"{% endif %}{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+<div {% if field_class %}class="{{ field_class }}"{% endif %}{% if flat_attrs %} {{ flat_attrs }}{% endif %}>
 
     {% for group, options, index in field|optgroups %}
     {% if group %}<strong>{{ group }}</strong>{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/column.html
+++ b/crispy_forms/templates/bootstrap4/layout/column.html
@@ -1,5 +1,5 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %}
-     class="{% if 'col' in div.css_class %}{{ div.css_class|default:'' }}{% else %}col-md {{ div.css_class|default:'' }}{% endif %}" {{ div.flat_attrs|safe }}>
+     class="{% if 'col' in div.css_class %}{{ div.css_class|default:'' }}{% else %}col-md {{ div.css_class|default:'' }}{% endif %}" {{ div.flat_attrs }}>
         {{ fields|safe }}
 </div>
 

--- a/crispy_forms/templates/bootstrap4/layout/div.html
+++ b/crispy_forms/templates/bootstrap4/layout/div.html
@@ -1,4 +1,4 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
-    {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs|safe }}>
+    {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs }}>
         {{ fields|safe }}
 </div>

--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -1,6 +1,6 @@
 {% load crispy_forms_field %}
 
-<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs|safe }}>
+<div{% if div.css_id %} id="{{ div.css_id }}"{% endif %} class="form-group{% if 'form-horizontal' in form_class %} row{% endif %}{% if wrapper_class %} {{ wrapper_class }}{% endif %}{% if field.css_classes %} {{ field.css_classes }}{% endif %}{% if div.css_class %} {{ div.css_class }}{% endif %}" {{ div.flat_attrs }}>
     {% if field.label and form_show_labels %}
         <label for="{{ field.id_for_label }}" class="{% if 'form-horizontal' in form_class %}col-form-label {% endif %}{{ label_class }}{% if field.field.required %} requiredField{% endif %}">
             {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/fieldset.html
+++ b/crispy_forms/templates/bootstrap4/layout/fieldset.html
@@ -1,6 +1,6 @@
 <fieldset {% if fieldset.css_id %}id="{{ fieldset.css_id }}"{% endif %} 
     {% if fieldset.css_class%}class="{{ fieldset.css_class }}"{% endif %}
-    {{ fieldset.flat_attrs|safe }}>
+    {{ fieldset.flat_attrs }}>
     {% if legend %}<legend>{{ legend|safe }}</legend>{% endif %}
     {{ fields|safe }} 
 </fieldset>

--- a/crispy_forms/templates/bootstrap4/layout/modal.html
+++ b/crispy_forms/templates/bootstrap4/layout/modal.html
@@ -1,4 +1,4 @@
-<div id="{{ modal.css_id }}" class="modal fade {{ modal.css_class }}" {{ modal.flat_attrs|safe }}>
+<div id="{{ modal.css_id }}" class="modal fade {{ modal.css_class }}" {{ modal.flat_attrs }}>
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header">

--- a/crispy_forms/templates/bootstrap4/layout/radioselect.html
+++ b/crispy_forms/templates/bootstrap4/layout/radioselect.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_filters %}
 {% load l10n %}
 
-<div {% if field_class %}class="{{ field_class }}"{% endif %}{% if flat_attrs %} {{ flat_attrs|safe }}{% endif %}>
+<div {% if field_class %}class="{{ field_class }}"{% endif %}{% if flat_attrs %} {{ flat_attrs }}{% endif %}>
 
     {% for group, options, index in field|optgroups %}
     {% if group %}<strong>{{ group }}</strong>{% endif %}

--- a/crispy_forms/templates/bootstrap4/layout/row.html
+++ b/crispy_forms/templates/bootstrap4/layout/row.html
@@ -1,3 +1,3 @@
-<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="form-row {{ div.css_class|default:'' }}" {{ div.flat_attrs|safe }}>
+<div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="form-row {{ div.css_class|default:'' }}" {{ div.flat_attrs }}>
         {{ fields|safe }}
 </div>

--- a/crispy_forms/templates/bootstrap4/table_inline_formset.html
+++ b/crispy_forms/templates/bootstrap4/table_inline_formset.html
@@ -4,7 +4,7 @@
 
 {% specialspaceless %}
 {% if formset_tag %}
-<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
+<form {{ flat_attrs }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
 {% endif %}
     {% if formset_method|lower == 'post' and not disable_csrf %}
         {% csrf_token %}

--- a/crispy_forms/templates/bootstrap4/whole_uni_form.html
+++ b/crispy_forms/templates/bootstrap4/whole_uni_form.html
@@ -1,7 +1,7 @@
 {% load crispy_forms_utils %}
 
 {% specialspaceless %}
-{% if form_tag %}<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>{% endif %}
+{% if form_tag %}<form {{ flat_attrs }} method="{{ form_method }}" {% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>{% endif %}
     {% if form_method|lower == 'post' and not disable_csrf %}
         {% csrf_token %}
     {% endif %}

--- a/crispy_forms/templates/bootstrap4/whole_uni_formset.html
+++ b/crispy_forms/templates/bootstrap4/whole_uni_formset.html
@@ -3,7 +3,7 @@
 
 {% specialspaceless %}
 {% if formset_tag %}
-<form {{ flat_attrs|safe }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
+<form {{ flat_attrs }} method="{{ form_method }}" {% if formset.is_multipart %} enctype="multipart/form-data"{% endif %}>
 {% endif %}
     {% if formset_method|lower == 'post' and not disable_csrf %}
         {% csrf_token %}


### PR DESCRIPTION
`flat_attrs` is passed via Django's `flatatt` which returns a `SafeString`. Therefore passing via `Safe` again is not required.