### PR TITLE
Made `Get_rendered_fields()` return `SafeString`.

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -1,6 +1,7 @@
 from django.template import Template
 from django.template.loader import render_to_string
 from django.utils.html import conditional_escape
+from django.utils.safestring import SafeString
 from django.utils.text import slugify
 
 from crispy_forms.utils import TEMPLATE_PACK, flatatt, get_template_pack, render_field
@@ -91,8 +92,8 @@ class LayoutObject(TemplateNameMixin):
         return pointers
 
     def get_rendered_fields(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
-        return "".join(
-            render_field(field, form, context, template_pack=template_pack, **kwargs) for field in self.fields
+        return SafeString(
+            "".join(render_field(field, form, context, template_pack=template_pack, **kwargs) for field in self.fields)
         )
 
 


### PR DESCRIPTION
This function calls `render_field()` for each field which always returns a `SafeString` however, due to the join with `""` this converts it to a `str`. Let's preserve the `SafeString` which will help `|safe` calls in templates to be removed.

`render_field()` will render a field via `Template.render()` (which returns a `SafeString`) or will call a `LayoutObjects` render method which should also return a `SafeString` via either calling `render_field()` again or calling `render_to_string()` which also returns a `SafeString`.