### PR TITLE
Made `Accordion.render()` render with `content` being a `SafeString`.

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -2,6 +2,7 @@ from random import randint
 
 from django.template import Template
 from django.template.loader import render_to_string
+from django.utils.safestring import SafeString
 from django.utils.text import slugify
 
 from .layout import Div, Field, LayoutObject, TemplateNameMixin
@@ -883,7 +884,7 @@ class Accordion(ContainerHolder):
             accordion_group.data_parent = self.css_id
 
     def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
-        content = ""
+        content = SafeString("")
 
         # Open the group that should be open.
         self.open_target_group_for_form(form)


### PR DESCRIPTION
`render_field()` returns a `SafeString` but a plain `str` is currently used as `""` is used to join the content. Marking the base content as `SafeString` allows the safe content to be preserved.

This will allow for removal of `|safe` filters in templates.