### PR TITLE
Removed `|safe` filter from `FieldWithButtons` templates.

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -460,17 +460,19 @@ class FieldWithButtons(Div):
     def render(self, form, context, template_pack=TEMPLATE_PACK, extra_context=None, **kwargs):
         # We first render the buttons
         field_template = self.field_template % template_pack
-        buttons = "".join(
-            render_field(
-                field,
-                form,
-                context,
-                field_template,
-                layout_object=self,
-                template_pack=template_pack,
-                **kwargs,
+        buttons = SafeString(
+            "".join(
+                render_field(
+                    field,
+                    form,
+                    context,
+                    field_template,
+                    layout_object=self,
+                    template_pack=template_pack,
+                    **kwargs,
+                )
+                for field in self.fields[1:]
             )
-            for field in self.fields[1:]
         )
 
         extra_context = {"div": self, "buttons": buttons}

--- a/crispy_forms/templates/bootstrap3/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap3/layout/field_with_buttons.html
@@ -10,7 +10,7 @@
     <div class="controls {{ field_class }}">
         <div class="input-group">
             {% crispy_field field %}
-            <span class="input-group-btn{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ buttons|safe }}</span>
+            <span class="input-group-btn{% if active %} active{% endif %}{% if input_size %} {{ input_size }}{% endif %}">{{ buttons }}</span>
         </div>
         {% include 'bootstrap3/layout/help_text_and_errors.html' %}
     </div>

--- a/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
+++ b/crispy_forms/templates/bootstrap4/layout/field_with_buttons.html
@@ -10,7 +10,7 @@
     <div class="{{ field_class }}">
         <div class="input-group {% if div.input_size %} {{ div.input_size }}{% endif %}">
             {% crispy_field field 'class' 'form-control' %}
-            <span class="input-group-append{% if active %} active{% endif %}">{{ buttons|safe }}</span>
+            <span class="input-group-append{% if active %} active{% endif %}">{{ buttons }}</span>
         </div>
         {% include 'bootstrap4/layout/help_text_and_errors.html' %}
     </div>


### PR DESCRIPTION
`render_field()` returns a SafeString so let's preserve that in the `context` so the `|safe` filter in the template is not required.