### PR TITLE
Removed unrequired `|safe` filters.

### DIFF
--- a/crispy_forms/templates/bootstrap3/accordion-group.html
+++ b/crispy_forms/templates/bootstrap3/accordion-group.html
@@ -6,7 +6,7 @@
     </div>
     <div id="{{ div.css_id }}" class="panel-collapse collapse{% if div.active %} in{% endif %}" >
         <div class="panel-body">
-            {{ fields|safe }}
+            {{ fields }}
         </div>
     </div>
 </div>

--- a/crispy_forms/templates/bootstrap3/accordion.html
+++ b/crispy_forms/templates/bootstrap3/accordion.html
@@ -1,3 +1,3 @@
 <div class="panel-group" id="{{ accordion.css_id }}">
-    {{ content|safe }}
+    {{ content }}
 </div>

--- a/crispy_forms/templates/bootstrap3/layout/alert.html
+++ b/crispy_forms/templates/bootstrap3/layout/alert.html
@@ -1,4 +1,4 @@
 <div{% if alert.css_id %} id="{{ alert.css_id }}"{% endif %}{% if alert.css_class %} class="{{ alert.css_class }}"{% endif %}>
     {% if dismiss %}<button type="button" class="close" data-dismiss="alert">&times;</button>{% endif %}
-    {{ content|safe }}
+    {{ content }}
 </div>

--- a/crispy_forms/templates/bootstrap3/layout/buttonholder.html
+++ b/crispy_forms/templates/bootstrap3/layout/buttonholder.html
@@ -1,4 +1,4 @@
 <div {% if buttonholder.css_id %}id="{{ buttonholder.css_id }}"{% endif %} 
     class="buttonHolder{% if buttonholder.css_class %} {{ buttonholder.css_class }}{% endif %}">
-       {{ fields_output|safe }}
+       {{ fields_output }}
 </div>

--- a/crispy_forms/templates/bootstrap3/layout/column.html
+++ b/crispy_forms/templates/bootstrap3/layout/column.html
@@ -1,3 +1,3 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="formColumn {{ div.css_class|default:'' }}" {{ div.flat_attrs }}>
-        {{ fields|safe }}
+        {{ fields }}
 </div>

--- a/crispy_forms/templates/bootstrap3/layout/div.html
+++ b/crispy_forms/templates/bootstrap3/layout/div.html
@@ -1,4 +1,4 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
     {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs }}>
-        {{ fields|safe }}
+        {{ fields }}
 </div>

--- a/crispy_forms/templates/bootstrap3/layout/fieldset.html
+++ b/crispy_forms/templates/bootstrap3/layout/fieldset.html
@@ -2,5 +2,5 @@
     {% if fieldset.css_class %}class="{{ fieldset.css_class }}"{% endif %}
     {{ fieldset.flat_attrs }}>
     {% if legend %}<legend>{{ legend|safe }}</legend>{% endif %}
-    {{ fields|safe }} 
+    {{ fields }} 
 </fieldset>

--- a/crispy_forms/templates/bootstrap3/layout/formactions.html
+++ b/crispy_forms/templates/bootstrap3/layout/formactions.html
@@ -4,6 +4,6 @@
     {% endif %}
 
     <div class="controls {{ field_class }}">
-        {{ fields_output|safe }}
+        {{ fields_output }}
     </div>
 </div>

--- a/crispy_forms/templates/bootstrap3/layout/modal.html
+++ b/crispy_forms/templates/bootstrap3/layout/modal.html
@@ -8,7 +8,7 @@
                 </button>
             </div>
             <div class="modal-body">
-                {{ fields|safe }}
+                {{ fields }}
             </div>
         </div>
     </div>

--- a/crispy_forms/templates/bootstrap3/layout/multifield.html
+++ b/crispy_forms/templates/bootstrap3/layout/multifield.html
@@ -15,11 +15,11 @@
     {% endif %}
 
     {% if multifield.label_html %}
-        <p {% if multifield.label_class %}class="{{ multifield.label_class }}"{% endif %}>{{ multifield.label_html|safe }}</p>
+        <p {% if multifield.label_class %}class="{{ multifield.label_class }}"{% endif %}>{{ multifield.label_html }}</p>
     {% endif %}
 
     <div class="multiField">
-        {{ fields_output|safe }}
+        {{ fields_output }}
     </div>
 
 </div>

--- a/crispy_forms/templates/bootstrap3/layout/row.html
+++ b/crispy_forms/templates/bootstrap3/layout/row.html
@@ -1,3 +1,3 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="row {{ div.css_class|default:'' }}" {{ div.flat_attrs }}>
-        {{ fields|safe }}
+        {{ fields }}
 </div>

--- a/crispy_forms/templates/bootstrap4/accordion-group.html
+++ b/crispy_forms/templates/bootstrap4/accordion-group.html
@@ -11,7 +11,7 @@
     <div id="{{ div.css_id }}" class="collapse{% if div.active %} show{% endif %}" role="tabpanel"
          aria-labelledby="{{ div.css_id }}" data-parent="#{{ div.data_parent }}">
         <div class="card-body">
-            {{ fields|safe }}
+            {{ fields }}
         </div>
     </div>
 </div>

--- a/crispy_forms/templates/bootstrap4/accordion.html
+++ b/crispy_forms/templates/bootstrap4/accordion.html
@@ -1,3 +1,3 @@
 <div id="{{ accordion.css_id }}" role="tablist">
-    {{ content|safe }}
+    {{ content }}
 </div>

--- a/crispy_forms/templates/bootstrap4/layout/alert.html
+++ b/crispy_forms/templates/bootstrap4/layout/alert.html
@@ -1,4 +1,4 @@
 <div{% if alert.css_id %} id="{{ alert.css_id }}"{% endif %}{% if alert.css_class %} class="{{ alert.css_class }}"{% endif %}>
     {% if dismiss %}<button type="button" class="close" data-dismiss="alert">&times;</button>{% endif %}
-    {{ content|safe }}
+    {{ content }}
 </div>

--- a/crispy_forms/templates/bootstrap4/layout/buttonholder.html
+++ b/crispy_forms/templates/bootstrap4/layout/buttonholder.html
@@ -1,4 +1,4 @@
 <div {% if buttonholder.css_id %}id="{{ buttonholder.css_id }}"{% endif %} 
     class="buttonHolder{% if buttonholder.css_class %} {{ buttonholder.css_class }}{% endif %}">
-       {{ fields_output|safe }}
+       {{ fields_output }}
 </div>

--- a/crispy_forms/templates/bootstrap4/layout/column.html
+++ b/crispy_forms/templates/bootstrap4/layout/column.html
@@ -1,6 +1,6 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %}
      class="{% if 'col' in div.css_class %}{{ div.css_class|default:'' }}{% else %}col-md {{ div.css_class|default:'' }}{% endif %}" {{ div.flat_attrs }}>
-        {{ fields|safe }}
+        {{ fields }}
 </div>
 
 

--- a/crispy_forms/templates/bootstrap4/layout/div.html
+++ b/crispy_forms/templates/bootstrap4/layout/div.html
@@ -1,4 +1,4 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} 
     {% if div.css_class %}class="{{ div.css_class }}"{% endif %} {{ div.flat_attrs }}>
-        {{ fields|safe }}
+        {{ fields }}
 </div>

--- a/crispy_forms/templates/bootstrap4/layout/fieldset.html
+++ b/crispy_forms/templates/bootstrap4/layout/fieldset.html
@@ -2,5 +2,5 @@
     {% if fieldset.css_class%}class="{{ fieldset.css_class }}"{% endif %}
     {{ fieldset.flat_attrs }}>
     {% if legend %}<legend>{{ legend|safe }}</legend>{% endif %}
-    {{ fields|safe }} 
+    {{ fields }} 
 </fieldset>

--- a/crispy_forms/templates/bootstrap4/layout/formactions.html
+++ b/crispy_forms/templates/bootstrap4/layout/formactions.html
@@ -4,6 +4,6 @@
     {% endif %}
 
     <div class="{{ field_class }}">
-        {{ fields_output|safe }}
+        {{ fields_output }}
     </div>
 </div>

--- a/crispy_forms/templates/bootstrap4/layout/modal.html
+++ b/crispy_forms/templates/bootstrap4/layout/modal.html
@@ -8,7 +8,7 @@
                 </button>
             </div>
             <div class="modal-body">
-                {{ fields|safe }}
+                {{ fields }}
             </div>
         </div>
     </div>

--- a/crispy_forms/templates/bootstrap4/layout/row.html
+++ b/crispy_forms/templates/bootstrap4/layout/row.html
@@ -1,3 +1,3 @@
 <div {% if div.css_id %}id="{{ div.css_id }}"{% endif %} class="form-row {{ div.css_class|default:'' }}" {{ div.flat_attrs }}>
-        {{ fields|safe }}
+        {{ fields }}
 </div>


### PR DESCRIPTION
The content for these fields is already a `SafeString` therefore the `|safe` filter is not required. 