### PR TITLE
Made `render_field()` return `SafeString` when `field_instance` is `None`.

### DIFF
--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -107,7 +107,7 @@ def render_field(  # noqa: C901
                     logging.warning("A field should only be rendered once: %s" % field, exc_info=sys.exc_info())
 
         if field_instance is None:
-            html = ""
+            html = SafeString("")
         else:
             if template is None:
                 if form.crispy_field_template is None:


### PR DESCRIPTION
Follow up to 082c8468c7ed3c6302de2201c0cafb71a280c6c3.