### PR TITLE
Simplified FormHelper.get_attributes().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * The `html5_required` attribute of `FormHelper` is removed. In all supported versions of Django the `required` attribute is provided by the core `forms` module. 
 * The `FormActions` layout object learnt a `css_id` kwarg to add an `id` to the rendered `<div>`
 * The `flat_attrs()` method of `FormActions` is removed. Attributes provided by `**kwargs` are now passed via the `flat_attrs` function during `__init__()` instead of with each call of `render()`.
+* The default values of "form_error_title" and "formset_error_title" of FormHelper changed from `None` to `""`.
 * Dropped support for Django 2.2.
 * Added support for Django 4.1.
 

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -188,8 +188,8 @@ class FormHelper(DynamicLayoutHandler):
     form_group_wrapper_class = ""
     layout = None
     form_tag = True
-    form_error_title = None
-    formset_error_title = None
+    form_error_title = ""
+    formset_error_title = ""
     form_show_errors = True
     render_unmentioned_fields = False
     render_hidden_fields = False
@@ -298,10 +298,12 @@ class FormHelper(DynamicLayoutHandler):
             "error_text_inline": self.error_text_inline,
             "field_class": self.field_class,
             "field_template": self.field_template or "%s/field.html" % template_pack,
+            "form_error_title": self.form_error_title.strip(),
             "form_method": self.form_method.strip(),
             "form_show_errors": self.form_show_errors,
             "form_show_labels": self.form_show_labels,
             "form_tag": self.form_tag,
+            "formset_error_title": self.formset_error_title.strip(),
             "help_text_inline": self.help_text_inline,
             "include_media": self.include_media,
             "label_class": self.label_class,
@@ -338,10 +340,6 @@ class FormHelper(DynamicLayoutHandler):
 
         if self.inputs:
             items["inputs"] = self.inputs
-        if self.form_error_title:
-            items["form_error_title"] = self.form_error_title.strip()
-        if self.formset_error_title:
-            items["formset_error_title"] = self.formset_error_title.strip()
 
         for attribute_name, value in self.__dict__.items():
             if (


### PR DESCRIPTION
Django Template Language has similar treatment for None and "". Therefore we can change the default value to an emptry string and add these items directly to the items dict.

Test coverage for this change added in a41abd701f403930aff427fff5b1dc2fc99553f7