### PR TITLE
Improved get_layout_objects() to return a list of Pointers. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   Support for Bootstrap 5 is provided by a 3rd party package under the `django-crispy-forms` organisation at 
   [crispy-bootstrap5](https://github.com/django-crispy-forms/crispy-bootstrap5).
 * Default template pack is now `bootstrap4` if the `CRISPY_TEMPLATE_PACK` setting is not provided.
+* The `get_layout_objects()` and `get_field_names()` functions of `LayoutObject` now return a list of `Pointers` rather than a list 
+  of lists. Pointers are a `dataclass` containing a list of `posistions` and the `name` of object/field. 
 * The `html5_required` attribute of `FormHelper` is removed. In all supported versions of Django the `required` attribute is provided by the core `forms` module. 
 * The `FormActions` layout object learnt a `css_id` kwarg to add an `id` to the rendered `<div>`
 * The `flat_attrs()` method of `FormActions` is removed. Attributes provided by `**kwargs` are now passed via the `flat_attrs` function during `__init__()` instead of with each call of `render()`.

--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -610,7 +610,7 @@ class Container(Div):
         """
         check if field_name is contained within tab.
         """
-        return field_name in (pointer[1] for pointer in self.get_field_names())
+        return field_name in (pointer.name for pointer in self.get_field_names())
 
     def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
         if self.active:

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -83,7 +83,7 @@ class DynamicLayoutHandler:
             filtered_field = []
             for pointer in layout_field_names:
                 # There can be an empty pointer
-                if len(pointer) == 2 and pointer.name == key:
+                if pointer.name == key:
                     filtered_field.append(pointer)
 
             return LayoutSlice(self.layout, filtered_field)

--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -45,7 +45,7 @@ class DynamicLayoutHandler:
         # Let's filter all fields with widgets like widget_type
         filtered_fields = []
         for pointer in layout_field_names:
-            if isinstance(self.form.fields[pointer[1]].widget, widget_type):
+            if isinstance(self.form.fields[pointer.name].widget, widget_type):
                 filtered_fields.append(pointer)
 
         return LayoutSlice(self.layout, filtered_fields)
@@ -60,7 +60,7 @@ class DynamicLayoutHandler:
         # Let's exclude all fields with widgets like widget_type
         filtered_fields = []
         for pointer in layout_field_names:
-            if not isinstance(self.form.fields[pointer[1]].widget, widget_type):
+            if not isinstance(self.form.fields[pointer.name].widget, widget_type):
                 filtered_fields.append(pointer)
 
         return LayoutSlice(self.layout, filtered_fields)
@@ -83,7 +83,7 @@ class DynamicLayoutHandler:
             filtered_field = []
             for pointer in layout_field_names:
                 # There can be an empty pointer
-                if len(pointer) == 2 and pointer[1] == key:
+                if len(pointer) == 2 and pointer.name == key:
                     filtered_field.append(pointer)
 
             return LayoutSlice(self.layout, filtered_field)

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -15,9 +15,6 @@ class Pointer:
     positions: List[int]
     name: str
 
-    def __len__(self):
-        return 2
-
 
 class TemplateNameMixin:
     def get_template_name(self, template_pack):

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+from typing import List
+
 from django.template import Template
 from django.template.loader import render_to_string
 from django.utils.html import conditional_escape
@@ -5,6 +8,15 @@ from django.utils.safestring import SafeString
 from django.utils.text import slugify
 
 from crispy_forms.utils import TEMPLATE_PACK, flatatt, render_field
+
+
+@dataclass
+class Pointer:
+    positions: List[int]
+    name: str
+
+    def __len__(self):
+        return 2
 
 
 class TemplateNameMixin:
@@ -43,24 +55,24 @@ class LayoutObject(TemplateNameMixin):
 
     def get_field_names(self, index=None):
         """
-        Returns a list of lists, those lists are named pointers. First parameter
-        is the location of the field, second one the name of the field. Example::
+        Returns a list of Pointers. First parameter is the location of the
+        field, second one the name of the field. Example::
 
             [
-                [[0,1,2], 'field_name1'],
-                [[0,3], 'field_name2']
+                Pointer([0,1,2], 'field_name1'),
+                Pointer([0,3], 'field_name2'),
             ]
         """
         return self.get_layout_objects(str, index=None, greedy=True)
 
     def get_layout_objects(self, *LayoutClasses, index=None, max_level=0, greedy=False):
         """
-        Returns a list of lists pointing to layout objects of any type matching
+        Returns a list of Pointers pointing to layout objects of any type matching
         `LayoutClasses`::
 
             [
-                [[0,1,2], 'div'],
-                [[0,3], 'field_name']
+                Pointer([0,1,2], 'div']),
+                Pointer([0,3], 'field_name'),
             ]
 
         :param max_level: An integer that indicates max level depth to reach when
@@ -79,9 +91,9 @@ class LayoutObject(TemplateNameMixin):
         for i, layout_object in enumerate(self.fields):
             if isinstance(layout_object, LayoutClasses):
                 if str_class:
-                    pointers.append([index + [i], layout_object])
+                    pointers.append(Pointer(index + [i], layout_object))
                 else:
-                    pointers.append([index + [i], layout_object.__class__.__name__.lower()])
+                    pointers.append(Pointer(index + [i], layout_object.__class__.__name__.lower()))
 
             # If it's a layout object and we haven't reached the max depth limit or greedy
             # we recursive call
@@ -647,7 +659,7 @@ class MultiField(LayoutObject):
     def render(self, form, context, template_pack=TEMPLATE_PACK, **kwargs):
         # If a field within MultiField contains errors
         if context["form_show_errors"]:
-            for field in (pointer[1] for pointer in self.get_field_names()):
+            for field in (pointer.name for pointer in self.get_field_names()):
                 if field in form.errors:
                     self.css_class += " error"
 

--- a/crispy_forms/layout_slice.py
+++ b/crispy_forms/layout_slice.py
@@ -49,18 +49,18 @@ class LayoutSlice:
         elif isinstance(self.slice, list):
             # A list of pointers  Ex: [[[0, 0], 'div'], [[0, 2, 3], 'field_name']]
             for pointer in self.slice:
-                position = pointer[0]
+                positions = pointer.positions
 
                 # If it's pointing first level
-                if len(position) == 1:
-                    function(self.layout, position[-1])
+                if len(positions) == 1:
+                    function(self.layout, positions[-1])
                 else:
-                    layout_object = self.layout.fields[position[0]]
-                    for i in position[1:-1]:
+                    layout_object = self.layout.fields[positions[0]]
+                    for i in positions[1:-1]:
                         layout_object = layout_object.fields[i]
 
                     try:
-                        function(layout_object, position[-1])
+                        function(layout_object, positions[-1])
                     except IndexError:
                         # We could avoid this exception, recalculating pointers.
                         # However this case is most of the time an undesired behavior
@@ -125,10 +125,10 @@ class LayoutSlice:
         elif isinstance(self.slice, list):
             # A list of pointers  Ex: [[[0, 0], 'div'], [[0, 2, 3], 'field_name']]
             for pointer in self.slice:
-                position = pointer[0]
+                positions = pointer.positions
 
-                layout_object = self.layout.fields[position[0]]
-                for i in position[1:]:
+                layout_object = self.layout.fields[positions[0]]
+                for i in positions[1:]:
                     previous_layout_object = layout_object
                     layout_object = layout_object.fields[i]
 

--- a/tests/test_dynamic_api.py
+++ b/tests/test_dynamic_api.py
@@ -5,7 +5,7 @@ from django import forms
 from crispy_forms.bootstrap import AppendedText
 from crispy_forms.exceptions import DynamicError
 from crispy_forms.helper import FormHelper, FormHelpersException
-from crispy_forms.layout import HTML, Div, Field, Fieldset, Layout, MultiField
+from crispy_forms.layout import HTML, Div, Field, Fieldset, Layout, MultiField, Pointer
 
 from .forms import SampleForm
 
@@ -148,16 +148,20 @@ def test_update_attributes_and_wrap_once():
 
 def test_get_layout_objects():
     layout_1 = Layout(Div())
-    assert layout_1.get_layout_objects(Div) == [[[0], "div"]]
+    assert layout_1.get_layout_objects(Div) == [Pointer([0], "div")]
 
     layout_2 = Layout(Div(Div(Div("email")), Div("password1"), "password2"))
-    assert layout_2.get_layout_objects(Div) == [[[0], "div"]]
-    assert layout_2.get_layout_objects(Div, max_level=1) == [[[0], "div"], [[0, 0], "div"], [[0, 1], "div"]]
+    assert layout_2.get_layout_objects(Div) == [Pointer([0], "div")]
+    assert layout_2.get_layout_objects(Div, max_level=1) == [
+        Pointer([0], "div"),
+        Pointer([0, 0], "div"),
+        Pointer([0, 1], "div"),
+    ]
     assert layout_2.get_layout_objects(Div, max_level=2) == [
-        [[0], "div"],
-        [[0, 0], "div"],
-        [[0, 0, 0], "div"],
-        [[0, 1], "div"],
+        Pointer([0], "div"),
+        Pointer([0, 0], "div"),
+        Pointer([0, 0, 0], "div"),
+        Pointer([0, 1], "div"),
     ]
 
     layout_3 = Layout(
@@ -165,7 +169,11 @@ def test_get_layout_objects():
         Div("password1"),
         "password2",
     )
-    assert layout_3.get_layout_objects(str, max_level=2) == [[[0], "email"], [[1, 0], "password1"], [[2], "password2"]]
+    assert layout_3.get_layout_objects(str, max_level=2) == [
+        Pointer([0], "email"),
+        Pointer([1, 0], "password1"),
+        Pointer([2], "password2"),
+    ]
 
     layout_4 = Layout(
         Div(
@@ -175,8 +183,12 @@ def test_get_layout_objects():
         Div("password"),
         "extra_field",
     )
-    assert layout_4.get_layout_objects(Div) == [[[0], "div"], [[1], "div"]]
-    assert layout_4.get_layout_objects(Div, max_level=1) == [[[0], "div"], [[0, 0], "div"], [[1], "div"]]
+    assert layout_4.get_layout_objects(Div) == [Pointer([0], "div"), Pointer([1], "div")]
+    assert layout_4.get_layout_objects(Div, max_level=1) == [
+        Pointer([0], "div"),
+        Pointer([0, 0], "div"),
+        Pointer([1], "div"),
+    ]
 
 
 def test_filter_and_wrap():
@@ -216,13 +228,13 @@ def test_filter_and_wrap_side_effects():
 
 def test_get_field_names():
     layout_1 = Div("field_name")
-    assert layout_1.get_field_names() == [[[0], "field_name"]]
+    assert layout_1.get_field_names() == [Pointer([0], "field_name")]
 
     layout_2 = Div(Div("field_name"))
-    assert layout_2.get_field_names() == [[[0, 0], "field_name"]]
+    assert layout_2.get_field_names() == [Pointer([0, 0], "field_name")]
 
     layout_3 = Div(Div("field_name"), "password")
-    assert layout_3.get_field_names() == [[[0, 0], "field_name"], [[1], "password"]]
+    assert layout_3.get_field_names() == [Pointer([0, 0], "field_name"), Pointer([1], "password")]
 
     layout_4 = Div(
         Div(
@@ -233,10 +245,10 @@ def test_get_field_names():
         "extra_field",
     )
     assert layout_4.get_field_names() == [
-        [[0, 0, 0], "field_name"],
-        [[0, 1], "field_name2"],
-        [[1, 0], "password"],
-        [[2], "extra_field"],
+        Pointer([0, 0, 0], "field_name"),
+        Pointer([0, 1], "field_name2"),
+        Pointer([1, 0], "password"),
+        Pointer([2], "extra_field"),
     ]
 
     layout_5 = Div(
@@ -247,31 +259,31 @@ def test_get_field_names():
         "extra_field",
     )
     assert layout_5.get_field_names() == [
-        [[0, 0], "field_name"],
-        [[0, 1], "field_name2"],
-        [[1], "extra_field"],
+        Pointer([0, 0], "field_name"),
+        Pointer([0, 1], "field_name2"),
+        Pointer([1], "extra_field"),
     ]
 
 
 def test_layout_get_field_names():
     layout_1 = Layout(Div("field_name"), "password")
     assert layout_1.get_field_names() == [
-        [[0, 0], "field_name"],
-        [[1], "password"],
+        Pointer([0, 0], "field_name"),
+        Pointer([1], "password"),
     ]
 
     layout_2 = Layout(Div("field_name"), "password", Fieldset("legend", "extra_field"))
     assert layout_2.get_field_names() == [
-        [[0, 0], "field_name"],
-        [[1], "password"],
-        [[2, 0], "extra_field"],
+        Pointer([0, 0], "field_name"),
+        Pointer([1], "password"),
+        Pointer([2, 0], "extra_field"),
     ]
 
     layout_3 = Layout(Div(Div(Div("email")), Div("password1"), "password2"))
     assert layout_3.get_field_names() == [
-        [[0, 0, 0, 0], "email"],
-        [[0, 1, 0], "password1"],
-        [[0, 2], "password2"],
+        Pointer([0, 0, 0, 0], "email"),
+        Pointer([0, 1, 0], "password1"),
+        Pointer([0, 2], "password2"),
     ]
 
 
@@ -280,8 +292,8 @@ def test_filter_by_widget(advanced_layout):
     form.helper = FormHelper(form)
     form.helper.layout = advanced_layout
     assert form.helper.filter_by_widget(forms.PasswordInput).slice == [
-        [[0, 1, 0, 0], "password1"],
-        [[0, 4, 0], "password2"],
+        Pointer([0, 1, 0, 0], "password1"),
+        Pointer([0, 4, 0], "password2"),
     ]
 
 
@@ -290,9 +302,9 @@ def test_exclude_by_widget(advanced_layout):
     form.helper = FormHelper(form)
     form.helper.layout = advanced_layout
     assert form.helper.exclude_by_widget(forms.PasswordInput).slice == [
-        [[0, 0, 0, 0], "email"],
-        [[0, 3, 0], "first_name"],
-        [[1], "last_name"],
+        Pointer([0, 0, 0, 0], "email"),
+        Pointer([0, 3, 0], "first_name"),
+        Pointer([1], "last_name"),
     ]
 
 
@@ -402,6 +414,10 @@ def test_filter():
         Div("password"),
         "extra_field",
     )
-    assert helper.filter(Div, MultiField).slice == [[[0], "div"], [[1], "div"]]
-    assert helper.filter(Div, MultiField, max_level=1).slice == [[[0], "div"], [[0, 0], "multifield"], [[1], "div"]]
-    assert helper.filter(MultiField, max_level=1).slice == [[[0, 0], "multifield"]]
+    assert helper.filter(Div, MultiField).slice == [Pointer([0], "div"), Pointer([1], "div")]
+    assert helper.filter(Div, MultiField, max_level=1).slice == [
+        Pointer([0], "div"),
+        Pointer([0, 0], "multifield"),
+        Pointer([1], "div"),
+    ]
+    assert helper.filter(MultiField, max_level=1).slice == [Pointer([0, 0], "multifield")]


### PR DESCRIPTION
The current implementation returns a list of lists.

Each list has two items:
- A list of locations (int)
- The name of the object/field. (str)

This PR replaces the list with a dataclass to improve the readability of the code and to help when adding type hints.

That is the current type is Union[List[int], str]. Accessing the first item can therefore by either of these types. However, we know the type is specifically List[int]. Using a dataclass allows each component to by typed individually.