### PR TITLE
Removed default template pack if CRISPY_TEMPLATE_PACK is not set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * Removed Bootstrap 2 template pack. Bootstrap 3 and 4 support is provided by the core crispy-forms package.
   Support for Bootstrap 5 is provided by a 3rd party package under the `django-crispy-forms` organisation at 
   [crispy-bootstrap5](https://github.com/django-crispy-forms/crispy-bootstrap5).
-* Default template pack is now `bootstrap4` if the `CRISPY_TEMPLATE_PACK` setting is not provided.
+* An attribute error is now raised if the `CRISPY_TEMPLATE_PACK` setting is not provided.
 * The `get_layout_objects()` and `get_field_names()` functions of `LayoutObject` now return a list of `Pointers` rather than a list 
   of lists. Pointers are a `dataclass` containing a list of `posistions` and the `name` of object/field. 
 * The `html5_required` attribute of `FormHelper` is removed. In all supported versions of Django the `required` attribute is provided by the core `forms` module. 

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -13,7 +13,7 @@ from .base import KeepContext
 
 
 def get_template_pack():
-    return getattr(settings, "CRISPY_TEMPLATE_PACK", "bootstrap4")
+    return getattr(settings, "CRISPY_TEMPLATE_PACK")
 
 
 TEMPLATE_PACK = SimpleLazyObject(get_template_pack)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -258,6 +258,7 @@ def test_optgroup_filter():
 @override_settings()
 def test_get_template_pack():
     del settings.CRISPY_TEMPLATE_PACK
-    assert get_template_pack() == "bootstrap4"
+    with pytest.raises(AttributeError):
+        get_template_pack()
     with pytest.raises(AttributeError):
         settings.CRISPY_TEMPLATE_PACK


### PR DESCRIPTION
In crispy-forms 1.x bootstrap (i.e. v2) was the default template pack. Now we're heading towards removing template packs in core we can't have a default.

A change will only be requited where folk are using the bootstrap2 template pack and have not added a setting.