### PR TITLE
Used dict instead of creating Context and calling Context.flatten().

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_field.py
+++ b/crispy_forms/templatetags/crispy_forms_field.py
@@ -1,6 +1,6 @@
 from django import forms, template
 from django.conf import settings
-from django.template import Context, Variable, loader
+from django.template import Variable, loader
 
 from crispy_forms.utils import get_template_pack
 
@@ -155,14 +155,14 @@ def crispy_addon(field, append="", prepend="", form_show_labels=True):
         {% crispy_addon form.my_field append=".00" %}
     """
     if field:
-        context = Context({"field": field, "form_show_errors": True, "form_show_labels": form_show_labels})
-        template = loader.get_template("%s/layout/prepended_appended_text.html" % get_template_pack())
-        context["crispy_prepended_text"] = prepend
-        context["crispy_appended_text"] = append
-
         if not prepend and not append:
             raise TypeError("Expected a prepend and/or append argument")
-
-        context = context.flatten()
-
+        context = {
+            "field": field,
+            "form_show_errors": True,
+            "form_show_labels": form_show_labels,
+            "crispy_prepended_text": prepend,
+            "crispy_appended_text": append,
+        }
+        template = loader.get_template("%s/layout/prepended_appended_text.html" % get_template_pack())
     return template.render(context)

--- a/crispy_forms/templatetags/crispy_forms_filters.py
+++ b/crispy_forms/templatetags/crispy_forms_filters.py
@@ -4,7 +4,6 @@ from django import template
 from django.conf import settings
 from django.forms import boundfield
 from django.forms.formsets import BaseFormSet
-from django.template import Context
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
 
@@ -45,15 +44,13 @@ def as_crispy_form(form, template_pack=TEMPLATE_PACK, label_class="", field_clas
 
         {{ myform|label_class:"col-lg-2",field_class:"col-lg-8" }}
     """
-    c = Context(
-        {
-            "field_class": field_class,
-            "field_template": "%s/field.html" % template_pack,
-            "form_show_errors": True,
-            "form_show_labels": True,
-            "label_class": label_class,
-        }
-    ).flatten()
+    c = {
+        "field_class": field_class,
+        "field_template": "%s/field.html" % template_pack,
+        "form_show_errors": True,
+        "form_show_labels": True,
+        "label_class": label_class,
+    }
     if isinstance(form, BaseFormSet):
         template = uni_formset_template(template_pack)
         c["formset"] = form
@@ -78,10 +75,10 @@ def as_crispy_errors(form, template_pack=TEMPLATE_PACK):
     """
     if isinstance(form, BaseFormSet):
         template = get_template("%s/errors_formset.html" % template_pack)
-        c = Context({"formset": form}).flatten()
+        c = {"formset": form}
     else:
         template = get_template("%s/errors.html" % template_pack)
-        c = Context({"form": form}).flatten()
+        c = {"form": form}
 
     return template.render(c)
 
@@ -118,8 +115,7 @@ def as_crispy_field(field, template_pack=TEMPLATE_PACK, label_class="", field_cl
         template_path = "%s/field.html" % template_pack
     template = get_template(template_path)
 
-    c = Context(attributes).flatten()
-    return template.render(c)
+    return template.render(attributes)
 
 
 @register.filter(name="flatatt")


### PR DESCRIPTION
The context being passed to render a template should be a dict. This PR changes a few cases where a Context is created, only to call flatten which converts it back to a dict. We can avoid this step by creating, and using a plain dict.
