### PR TITLE
Improved tests --  Test whole form instead of HTML snippets.

### DIFF
--- a/tests/results/test_formset_layout.html
+++ b/tests/results/test_formset_layout.html
@@ -1,0 +1,144 @@
+<form action="/simple/action/" class="formsets-that-rock" id="thisFormsetRocks" method="post"> 
+    <input type="hidden" name="csrfmiddlewaretoken" value="aTestToken">
+    <div>
+        <input type="hidden" name="form-TOTAL_FORMS" value="3" id="id_form-TOTAL_FORMS"> 
+        <input type="hidden" name="form-INITIAL_FORMS" value="0" id="id_form-INITIAL_FORMS">
+        <input type="hidden" name="form-MIN_NUM_FORMS" value="0" id="id_form-MIN_NUM_FORMS">
+        <input type="hidden" name="form-MAX_NUM_FORMS" value="1000" id="id_form-MAX_NUM_FORMS">
+    </div>
+    <fieldset>
+        <legend>Item 1</legend>
+        <div class="form-group">
+            <div id="div_id_form-0-is_company" class="checkbox"> 
+                <label for="id_form-0-is_company" class="">
+                    <input type="checkbox" name="form-0-is_company" class="checkboxinput" id="id_form-0-is_company">
+                    company
+                </label>
+            </div>
+        </div>
+        <div id="div_id_form-0-email" class="form-group">
+            <label for="id_form-0-email" class="control-label  requiredField"> email<span class="asteriskField">*</span></label>
+            <div class="controls ">
+                <input type="text" name="form-0-email" maxlength="30" class="textinput textInput inputtext form-control" id="id_form-0-email">
+                <div id="hint_id_form-0-email" class="help-block">Insert your email</div>
+            </div>
+        </div>
+    </fieldset>
+    Note for first form only
+    <div class="row ">
+        <div id="div_id_form-0-password1" class="form-group">
+            <label for="id_form-0-password1" class="control-label  requiredField"> password<span class="asteriskField">*</span></label>
+            <div class="controls ">
+                <input type="password" name="form-0-password1" maxlength="30" class="passwordinput form-control" id="id_form-0-password1">
+            </div>
+        </div>
+        <div id="div_id_form-0-password2" class="form-group">
+            <label for="id_form-0-password2" class="control-label  requiredField"> re-enter password<span class="asteriskField">*</span></label>
+            <div class="controls ">
+                <input type="password" name="form-0-password2" maxlength="30" class="passwordinput form-control" id="id_form-0-password2">
+            </div>
+        </div>
+    </div>
+    <fieldset>
+        <div id="div_id_form-0-first_name" class="form-group">
+            <label for="id_form-0-first_name" class="control-label  requiredField"> first name<span class="asteriskField">*</span></label>
+            <div class="controls ">
+                <input type="text" name="form-0-first_name" maxlength="5" class="textinput textInput inputtext form-control" id="id_form-0-first_name">
+            </div>
+        </div>
+        <div id="div_id_form-0-last_name" class="form-group">
+            <label for="id_form-0-last_name" class="control-label  requiredField"> last name<span class="asteriskField">*</span></label>
+            <div class="controls ">
+                <input type="text" name="form-0-last_name" maxlength="5" class="textinput textInput inputtext form-control" id="id_form-0-last_name"> 
+            </div>
+        </div>
+    </fieldset>
+    <fieldset>
+        <legend>Item 2</legend>
+        <div class="form-group">
+            <div id="div_id_form-1-is_company" class="checkbox"> 
+                <label for="id_form-1-is_company" class=""> 
+                    <input type="checkbox" name="form-1-is_company" class="checkboxinput" id="id_form-1-is_company">
+                    company
+                </label> 
+            </div>
+        </div>
+        <div id="div_id_form-1-email" class="form-group">
+            <label for="id_form-1-email" class="control-label  requiredField"> email<span class="asteriskField">*</span></label>
+            <div class="controls "> 
+                <input type="text" name="form-1-email" maxlength="30" class="textinput textInput inputtext form-control" id="id_form-1-email">
+                <div id="hint_id_form-1-email" class="help-block">Insert your email</div>
+            </div>
+        </div>
+    </fieldset>
+    <div class="row ">
+        <div id="div_id_form-1-password1" class="form-group"> 
+            <label for="id_form-1-password1" class="control-label  requiredField"> password<span class="asteriskField">*</span></label>
+            <div class="controls ">
+                <input type="password" name="form-1-password1" maxlength="30" class="passwordinput form-control" id="id_form-1-password1">
+            </div>
+        </div>
+        <div id="div_id_form-1-password2" class="form-group"> 
+            <label for="id_form-1-password2" class="control-label  requiredField"> re-enter password<span class="asteriskField">*</span></label>
+            <div class="controls ">
+                <input type="password" name="form-1-password2" maxlength="30" class="passwordinput form-control" id="id_form-1-password2"> 
+            </div>
+        </div>
+    </div>
+    <fieldset>
+        <div id="div_id_form-1-first_name" class="form-group"> 
+            <label for="id_form-1-first_name" class="control-label  requiredField"> first name<span class="asteriskField">*</span></label>
+            <div class="controls ">
+                <input type="text" name="form-1-first_name" maxlength="5" class="textinput textInput inputtext form-control" id="id_form-1-first_name">
+            </div>
+        </div>
+        <div id="div_id_form-1-last_name" class="form-group"> 
+            <label for="id_form-1-last_name" class="control-label  requiredField"> last name<span class="asteriskField">*</span> </label>
+            <div class="controls "> 
+                <input type="text" name="form-1-last_name" maxlength="5" class="textinput textInput inputtext form-control" id="id_form-1-last_name"> 
+            </div>
+        </div>
+    </fieldset>
+    <fieldset>
+        <legend>Item 3</legend>
+        <div class="form-group">
+            <div id="div_id_form-2-is_company" class="checkbox"> 
+                <label for="id_form-2-is_company" class=""> 
+                    <input type="checkbox" name="form-2-is_company" class="checkboxinput" id="id_form-2-is_company">
+                    company
+                </label> 
+            </div>
+        </div>
+        <div id="div_id_form-2-email" class="form-group"> 
+            <label for="id_form-2-email" class="control-label  requiredField"> email<span class="asteriskField">*</span> </label>
+            <div class="controls "> 
+                <input type="text" name="form-2-email" maxlength="30" class="textinput textInput inputtext form-control" id="id_form-2-email">
+                <div id="hint_id_form-2-email" class="help-block">Insert your email</div>
+            </div>
+        </div>
+    </fieldset>
+    <div class="row ">
+        <div id="div_id_form-2-password1" class="form-group"> 
+            <label for="id_form-2-password1" class="control-label  requiredField"> password<span class="asteriskField">*</span> </label>
+            <div class="controls "> 
+                <input type="password" name="form-2-password1" maxlength="30" class="passwordinput form-control" id="id_form-2-password1"> </div>
+        </div>
+        <div id="div_id_form-2-password2" class="form-group"> 
+            <label for="id_form-2-password2" class="control-label  requiredField"> re-enter password<span class="asteriskField">*</span> </label>
+            <div class="controls "> 
+                <input type="password" name="form-2-password2" maxlength="30" class="passwordinput form-control" id="id_form-2-password2"> </div>
+        </div>
+    </div>
+    <fieldset>
+        <div id="div_id_form-2-first_name" class="form-group"> 
+            <label for="id_form-2-first_name" class="control-label  requiredField"> first name<span class="asteriskField">*</span> </label>
+            <div class="controls "> 
+                <input type="text" name="form-2-first_name" maxlength="5" class="textinput textInput inputtext form-control" id="id_form-2-first_name"> </div>
+        </div>
+        <div id="div_id_form-2-last_name" class="form-group"> 
+            <label for="id_form-2-last_name" class="control-label  requiredField"> last name<span class="asteriskField">*</span> </label>
+            <div class="controls "> 
+                <input type="text" name="form-2-last_name" maxlength="5" class="textinput textInput inputtext form-control" id="id_form-2-last_name"> </div>
+        </div>
+    </fieldset>
+</form>

--- a/tests/results/test_modelformset_layout.html
+++ b/tests/results/test_modelformset_layout.html
@@ -1,0 +1,32 @@
+<form method="post">
+    <div>
+      <input type="hidden" name="form-TOTAL_FORMS" value="3" id="id_form-TOTAL_FORMS">
+      <input type="hidden" name="form-INITIAL_FORMS" value="0" id="id_form-INITIAL_FORMS">
+      <input type="hidden" name="form-MIN_NUM_FORMS" value="0" id="id_form-MIN_NUM_FORMS">
+      <input type="hidden" name="form-MAX_NUM_FORMS" value="1000" id="id_form-MAX_NUM_FORMS">
+    </div>
+    <div id="div_id_form-0-email" class="form-group">
+      <label for="id_form-0-email" class="control-label  requiredField">Email <span class="asteriskField">*</span>
+      </label>
+      <div class="controls ">
+        <input type="text" name="form-0-email" maxlength="20" class="textinput textInput inputtext form-control" id="id_form-0-email">
+      </div>
+    </div>
+    <input type="hidden" name="form-0-id" id="id_form-0-id">
+    <div id="div_id_form-1-email" class="form-group">
+      <label for="id_form-1-email" class="control-label  requiredField">Email <span class="asteriskField">*</span>
+      </label>
+      <div class="controls ">
+        <input type="text" name="form-1-email" maxlength="20" class="textinput textInput inputtext form-control" id="id_form-1-email">
+      </div>
+    </div>
+    <input type="hidden" name="form-1-id" id="id_form-1-id">
+    <div id="div_id_form-2-email" class="form-group">
+      <label for="id_form-2-email" class="control-label  requiredField">Email <span class="asteriskField">*</span>
+      </label>
+      <div class="controls ">
+        <input type="text" name="form-2-email" maxlength="20" class="textinput textInput inputtext form-control" id="id_form-2-email">
+      </div>
+    </div>
+    <input type="hidden" name="form-2-id" id="id_form-2-id">
+</form>

--- a/tests/results/test_render_hidden_fields.html
+++ b/tests/results/test_render_hidden_fields.html
@@ -1,0 +1,11 @@
+<form method="post">
+    <div id="div_id_email" class="form-group">
+        <label for="id_email" class="control-label  requiredField">email<span class="asteriskField">*</span></label>
+        <div class="controls ">
+            <input type="text" name="email" maxlength="30" class="textinput textInput inputtext form-control" required id="id_email">
+            <div id="hint_id_email" class="help-block">Insert your email</div>
+        </div>
+    </div>
+    <input type="hidden" name="password1" id="id_password1">
+    <input type="hidden" name="password2" id="id_password2">
+</form>

--- a/tests/test_form_helper.py
+++ b/tests/test_form_helper.py
@@ -434,8 +434,6 @@ def test_render_unmentioned_fields_order():
 
 
 def test_render_hidden_fields():
-    from .utils import contains_partial
-
     test_form = SampleForm()
     test_form.helper = FormHelper()
     test_form.helper.layout = Layout("email")
@@ -447,13 +445,7 @@ def test_render_hidden_fields():
     # Now hide a couple of fields
     for field in ("password1", "password2"):
         test_form.fields[field].widget = forms.HiddenInput()
-
-    html = render_crispy_form(test_form)
-    assert html.count("<input") == 3
-    assert html.count("hidden") == 2
-
-    assert contains_partial(html, '<input name="password1" type="hidden"/>')
-    assert contains_partial(html, '<input name="password2" type="hidden"/>')
+    assert parse_expected("test_render_hidden_fields.html") == parse_form(test_form)
 
 
 def test_render_required_fields():


### PR DESCRIPTION
These tests are for core functionality rather than template specific. The results for these tests are therefore core folder and will stay around once bootstrap3 template pack is dropped (even though that pack is required for this test). 

Doing this means that we no longer rely on `contains_partial` and so we can consider removing that helper function (it's in the test suite, not the core library) and associated tests. 
