### PR TITLE
Removed tests.contains_partial

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from django import forms
 from django.conf import settings
 from django.template.base import Template
 from django.template.context import Context
-from django.test import SimpleTestCase, override_settings
+from django.test import override_settings
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout
@@ -12,7 +12,7 @@ from crispy_forms.templatetags.crispy_forms_filters import optgroups
 from crispy_forms.utils import get_template_pack, list_difference, list_intersection, render_field
 
 from .forms import GroupedChoiceForm, SampleForm, SampleForm5
-from .utils import contains_partial, parse_expected, parse_form
+from .utils import parse_expected, parse_form
 
 
 def test_list_intersection():
@@ -54,37 +54,6 @@ def test_custom_bound_field():
     rendered = template.render(Context({"form": MyForm(data={"f": "something"})}))
 
     assert extra in rendered
-
-
-def test_contains_partial():
-    c = SimpleTestCase()
-    needle = "<span></span>"
-    html = "<form>%s</form>"
-    c.assertTrue(contains_partial(html % needle, needle))
-
-    needle = "<span></span><b></b>"
-    c.assertRaises(NotImplementedError, contains_partial, html % needle, needle)
-
-    needle = "<span>a</span>"
-    c.assertRaises(NotImplementedError, contains_partial, html % needle, needle)
-
-    needle = '<span id="e"></span>'
-    html = '<form id="tt"><span id="f"></span>%s</form>'
-    c.assertTrue(contains_partial(html % needle, needle))
-
-    missing = "<script></script>"
-    c.assertFalse(contains_partial(html % missing, needle))
-
-    needle = '<span id="e"></span>'
-    html = '<form id="tt"><span id="f"></span>%s</form>'
-    missing = '<span id="g"></span>'
-    c.assertFalse(contains_partial(html % missing, needle))
-
-    needle = '<div id="r"><span>toto</span></div>'
-    html = '<form><div id="r"></div></form>'
-    c.assertRaises(NotImplementedError, contains_partial, html, needle)
-    # as we do not look at the children, needle is equivalent to <div id="r"></div> which IS in html
-    c.assertTrue(contains_partial(html, needle, ignore_needle_children=True))
 
 
 def test_parse_expected_and_form():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,32 +1,11 @@
 import os
 from pathlib import Path
 
-from django.test.html import Element, parse_html
+from django.test.html import parse_html
 
 from crispy_forms.utils import render_crispy_form
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
-
-
-def contains_partial(haystack, needle, ignore_needle_children=False):
-    """Search for a html element with at least the corresponding elements
-    (other elements may be present in the matched element from the haystack)
-    """
-    if not isinstance(haystack, Element):
-        haystack = parse_html(haystack)
-    if not isinstance(needle, Element):
-        needle = parse_html(needle)
-
-    if len(needle.children) > 0 and not ignore_needle_children:
-        raise NotImplementedError("contains_partial does not check needle's children:%s" % str(needle.children))
-
-    if needle.name == haystack.name and set(needle.attributes).issubset(haystack.attributes):
-        return True
-    return any(
-        contains_partial(child, needle, ignore_needle_children=ignore_needle_children)
-        for child in haystack.children
-        if isinstance(child, Element)
-    )
 
 
 def parse_expected(expected_file):


### PR DESCRIPTION
This is no longer required since 395a4e936db41bb2a5d70b50face287feeba55c7

I think we should prefer asserting the whole form rather than html chunks in python code. 