### PR TITLE
Added FormHelper() to test forms

### DIFF
--- a/tests/forms.py
+++ b/tests/forms.py
@@ -4,7 +4,19 @@ from django.db import models
 from crispy_forms.helper import FormHelper
 
 
-class SampleForm(forms.Form):
+class BaseForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+
+
+class BaseModelForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+
+
+class SampleForm(BaseForm):
     is_company = forms.CharField(label="company", required=False, widget=forms.CheckboxInput())
     email = forms.EmailField(
         label="email", max_length=30, required=True, widget=forms.TextInput(), help_text="Insert your email"
@@ -26,12 +38,10 @@ class SampleForm(forms.Form):
 
 
 class SampleForm2(SampleForm):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.helper = FormHelper(self)
+    pass
 
 
-class CheckboxesSampleForm(forms.Form):
+class CheckboxesSampleForm(BaseForm):
     checkboxes = forms.MultipleChoiceField(
         choices=((1, "Option one"), (2, "Option two"), (3, "Option three")),
         initial=(1,),
@@ -60,7 +70,7 @@ class CheckboxesSampleForm(forms.Form):
     )
 
 
-class SelectSampleForm(forms.Form):
+class SelectSampleForm(BaseForm):
     select = forms.ChoiceField(
         choices=((1, "Option one"), (2, "Option two"), (3, "Option three")), initial=(1,), widget=forms.Select
     )
@@ -71,7 +81,7 @@ class CrispyTestModel(models.Model):
     password = models.CharField(max_length=20)
 
 
-class SampleForm3(forms.ModelForm):
+class SampleForm3(BaseModelForm):
     class Meta:
         model = CrispyTestModel
         fields = ["email", "password"]
@@ -82,7 +92,7 @@ class SampleForm3(forms.ModelForm):
         self.helper = FormHelper(self)
 
 
-class SampleForm4(forms.ModelForm):
+class SampleForm4(BaseModelForm):
     class Meta:
         """
         before Django1.6, one cannot use __all__ shortcut for fields
@@ -95,7 +105,7 @@ class SampleForm4(forms.ModelForm):
         fields = "__all__"  # eliminate RemovedInDjango18Warning
 
 
-class SampleForm5(forms.Form):
+class SampleForm5(BaseForm):
     choices = [
         (1, 1),
         (2, 2),
@@ -106,13 +116,13 @@ class SampleForm5(forms.Form):
     pk = forms.IntegerField()
 
 
-class SampleFormWithMedia(forms.Form):
+class SampleFormWithMedia(BaseForm):
     class Media:
         css = {"all": ("test.css",)}
         js = ("test.js",)
 
 
-class SampleFormWithMultiValueField(forms.Form):
+class SampleFormWithMultiValueField(BaseForm):
     multi = forms.SplitDateTimeField()
 
 
@@ -125,7 +135,7 @@ class CrispyEmptyChoiceTestModel(models.Model):
     )
 
 
-class SampleForm6(forms.ModelForm):
+class SampleForm6(BaseModelForm):
     class Meta:
         """
         When allowing null=True in a model field,
@@ -142,7 +152,7 @@ class SampleForm6(forms.ModelForm):
         widgets = {"fruit": forms.RadioSelect()}
 
 
-class SampleForm7(forms.ModelForm):
+class SampleForm7(BaseModelForm):
     is_company = forms.CharField(label="company", required=False, widget=forms.CheckboxInput())
     password2 = forms.CharField(label="re-enter password", max_length=30, required=True, widget=forms.PasswordInput())
 
@@ -151,7 +161,7 @@ class SampleForm7(forms.ModelForm):
         fields = ("email", "password", "password2")
 
 
-class SampleForm8(forms.ModelForm):
+class SampleForm8(BaseModelForm):
     is_company = forms.CharField(label="company", required=False, widget=forms.CheckboxInput())
     password2 = forms.CharField(label="re-enter password", max_length=30, required=True, widget=forms.PasswordInput())
 
@@ -172,19 +182,19 @@ class FakeFieldFile:
         return self.url
 
 
-class FileForm(forms.Form):
+class FileForm(BaseForm):
     file_field = forms.FileField(widget=forms.FileInput)
     clearable_file = forms.FileField(widget=forms.ClearableFileInput, required=False, initial=FakeFieldFile())
 
 
-class AdvancedFileForm(forms.Form):
+class AdvancedFileForm(BaseForm):
     file_field = forms.FileField(widget=forms.FileInput(attrs={"class": "my-custom-class"}))
     clearable_file = forms.FileField(
         widget=forms.ClearableFileInput(attrs={"class": "my-custom-class"}), required=False, initial=FakeFieldFile()
     )
 
 
-class GroupedChoiceForm(forms.Form):
+class GroupedChoiceForm(BaseForm):
     choices = [
         (
             "Audio",
@@ -214,7 +224,7 @@ class CustomCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
     pass
 
 
-class SampleFormCustomWidgets(forms.Form):
+class SampleFormCustomWidgets(BaseForm):
     inline_radios = forms.ChoiceField(
         choices=(
             ("option_one", "Option one"),

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -37,10 +37,6 @@ class SampleForm(BaseForm):
         return self.cleaned_data
 
 
-class SampleForm2(SampleForm):
-    pass
-
-
 class CheckboxesSampleForm(BaseForm):
     checkboxes = forms.MultipleChoiceField(
         choices=((1, "Option one"), (2, "Option two"), (3, "Option three")),
@@ -86,10 +82,6 @@ class SampleForm3(BaseModelForm):
         model = CrispyTestModel
         fields = ["email", "password"]
         exclude = ["password"]
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.helper = FormHelper(self)
 
 
 class SampleForm4(BaseModelForm):

--- a/tests/test_dynamic_api.py
+++ b/tests/test_dynamic_api.py
@@ -289,7 +289,6 @@ def test_layout_get_field_names():
 
 def test_filter_by_widget(advanced_layout):
     form = SampleForm()
-    form.helper = FormHelper(form)
     form.helper.layout = advanced_layout
     assert form.helper.filter_by_widget(forms.PasswordInput).slice == [
         Pointer([0, 1, 0, 0], "password1"),
@@ -299,7 +298,6 @@ def test_filter_by_widget(advanced_layout):
 
 def test_exclude_by_widget(advanced_layout):
     form = SampleForm()
-    form.helper = FormHelper(form)
     form.helper.layout = advanced_layout
     assert form.helper.exclude_by_widget(forms.PasswordInput).slice == [
         Pointer([0, 0, 0, 0], "email"),
@@ -310,7 +308,6 @@ def test_exclude_by_widget(advanced_layout):
 
 def test_exclude_by_widget_and_wrap(advanced_layout):
     form = SampleForm()
-    form.helper = FormHelper(form)
     form.helper.layout = advanced_layout
     form.helper.exclude_by_widget(forms.PasswordInput).wrap(Field, css_class="hero")
     # Check wrapped fields
@@ -325,14 +322,12 @@ def test_exclude_by_widget_and_wrap(advanced_layout):
 
 def test_all_without_layout():
     form = SampleForm()
-    form.helper = FormHelper()
     with pytest.raises(FormHelpersException):
         form.helper.all().wrap(Div)
 
 
 def test_filter_by_widget_without_form(advanced_layout):
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.layout = advanced_layout
     with pytest.raises(FormHelpersException):
         form.helper.filter_by_widget(forms.PasswordInput)

--- a/tests/test_dynamic_api.py
+++ b/tests/test_dynamic_api.py
@@ -322,12 +322,14 @@ def test_exclude_by_widget_and_wrap(advanced_layout):
 
 def test_all_without_layout():
     form = SampleForm()
+    form.helper = FormHelper()  # reset helper to remove default layout
     with pytest.raises(FormHelpersException):
         form.helper.all().wrap(Div)
 
 
 def test_filter_by_widget_without_form(advanced_layout):
     form = SampleForm()
+    form.helper = FormHelper()  # reset helper to remove default layout
     form.helper.layout = advanced_layout
     with pytest.raises(FormHelpersException):
         form.helper.filter_by_widget(forms.PasswordInput)

--- a/tests/test_form_helper.py
+++ b/tests/test_form_helper.py
@@ -95,7 +95,6 @@ def test_form_with_helper_without_layout():
 
 def test_html5_required():
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.html5_required = True
     html = render_crispy_form(form)
     # 6 out of 7 fields are required and an extra one for the SplitDateTimeWidget makes 7.
@@ -105,14 +104,12 @@ def test_html5_required():
         assert len(re.findall(r"\brequired\b", html)) == 7
 
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.html5_required = False
     html = render_crispy_form(form)
 
 
 def test_media_is_included_by_default_with_bootstrap3():
     form = SampleFormWithMedia()
-    form.helper = FormHelper()
     form.helper.template_pack = "bootstrap3"
     html = render_crispy_form(form)
     assert "test.css" in html
@@ -121,7 +118,6 @@ def test_media_is_included_by_default_with_bootstrap3():
 
 def test_media_removed_when_include_media_is_false_with_bootstrap3():
     form = SampleFormWithMedia()
-    form.helper = FormHelper()
     form.helper.template_pack = "bootstrap3"
     form.helper.include_media = False
     html = render_crispy_form(form)
@@ -131,7 +127,6 @@ def test_media_removed_when_include_media_is_false_with_bootstrap3():
 
 def test_attrs():
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.attrs = {"id": "TestIdForm", "autocomplete": "off"}
     html = render_crispy_form(form)
 
@@ -336,15 +331,13 @@ def test_CSRF_token_GET_form():
 
 def test_disable_csrf():
     form = SampleForm()
-    helper = FormHelper()
-    helper.disable_csrf = True
-    html = render_crispy_form(form, helper, {"csrf_token": _get_new_csrf_string()})
+    form.helper.disable_csrf = True
+    html = render_crispy_form(form, form.helper, {"csrf_token": _get_new_csrf_string()})
     assert "csrf" not in html
 
 
 def test_render_unmentioned_fields():
     test_form = SampleForm()
-    test_form.helper = FormHelper()
     test_form.helper.layout = Layout("email")
     test_form.helper.render_unmentioned_fields = True
 
@@ -354,7 +347,6 @@ def test_render_unmentioned_fields():
 
 def test_render_unmentioned_fields_order():
     test_form = SampleForm7()
-    test_form.helper = FormHelper()
     test_form.helper.layout = Layout("email")
     test_form.helper.render_unmentioned_fields = True
 
@@ -371,7 +363,6 @@ def test_render_unmentioned_fields_order():
     )
 
     test_form = SampleForm8()
-    test_form.helper = FormHelper()
     test_form.helper.layout = Layout("email")
     test_form.helper.render_unmentioned_fields = True
 
@@ -390,7 +381,6 @@ def test_render_unmentioned_fields_order():
 
 def test_render_hidden_fields():
     test_form = SampleForm()
-    test_form.helper = FormHelper()
     test_form.helper.layout = Layout("email")
     test_form.helper.render_hidden_fields = True
 
@@ -405,7 +395,6 @@ def test_render_hidden_fields():
 
 def test_render_required_fields():
     test_form = SampleForm()
-    test_form.helper = FormHelper()
     test_form.helper.layout = Layout("email")
     test_form.helper.render_required_fields = True
 
@@ -415,7 +404,6 @@ def test_render_required_fields():
 
 def test_helper_custom_template():
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.template = "custom_form_template.html"
 
     html = render_crispy_form(form)
@@ -424,7 +412,6 @@ def test_helper_custom_template():
 
 def test_helper_custom_field_template():
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout("password1", "password2")
     form.helper.field_template = "custom_field_template.html"
 
@@ -434,7 +421,6 @@ def test_helper_custom_field_template():
 
 def test_helper_custom_field_template_no_layout():
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.field_template = "custom_field_template.html"
 
     html = render_crispy_form(form)
@@ -445,7 +431,6 @@ def test_helper_custom_field_template_no_layout():
 
 def test_helper_std_field_template_no_layout():
     form = SampleForm()
-    form.helper = FormHelper()
 
     html = render_crispy_form(form)
     for field in form.fields:
@@ -454,7 +439,6 @@ def test_helper_std_field_template_no_layout():
 
 def test_error_text_inline():
     form = SampleForm({"email": "invalidemail"})
-    form.helper = FormHelper()
     layout = Layout(
         AppendedText("first_name", "wat"),
         PrependedText("email", "@"),
@@ -472,7 +456,6 @@ def test_error_text_inline():
     assert len(matches) == 3
 
     form = SampleForm({"email": "invalidemail"})
-    form.helper = FormHelper()
     form.helper.layout = layout
     form.helper.error_text_inline = False
     html = render_crispy_form(form)
@@ -485,7 +468,6 @@ def test_error_text_inline():
 
 def test_form_show_labels():
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         "password1",
         FieldWithButtons("password2", StrictButton("Confirm")),
@@ -505,7 +487,6 @@ def test_passthrough_context():
     the crispy form into the crispy form templates.
     """
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.template = "custom_form_template_with_context.html"
 
     c = {"prefix": "foo", "suffix": "bar"}

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -196,8 +196,7 @@ def test_change_layout_dynamically_delete_field():
     )
 
     form = SampleForm()
-    form_helper = FormHelper()
-    form_helper.add_layout(
+    form.helper.add_layout(
         Layout(
             Fieldset(
                 "Company Data",
@@ -218,9 +217,9 @@ def test_change_layout_dynamically_delete_field():
     # We remove email field on the go
     # Layout needs to be adapted for the new form fields
     del form.fields["email"]
-    del form_helper.layout.fields[0].fields[1]
+    del form.helper.layout.fields[0].fields[1]
 
-    c = Context({"form": form, "form_helper": form_helper})
+    c = Context({"form": form, "form_helper": form.helper})
     html = template.render(c)
     assert "email" not in html
 
@@ -264,8 +263,7 @@ def test_i18n():
     """
     )
     form = SampleForm()
-    form_helper = FormHelper()
-    form_helper.layout = Layout(
+    form.helper.layout = Layout(
         HTML(_("i18n text")),
         Fieldset(
             _("i18n legend"),
@@ -273,8 +271,6 @@ def test_i18n():
             "last_name",
         ),
     )
-    form.helper = form_helper
-
     html = template.render(Context({"form": form}))
     assert html.count("i18n legend") == 1
 
@@ -299,7 +295,6 @@ def test_default_layout_two():
 
 def test_modelform_layout_without_meta():
     test_form = SampleForm4()
-    test_form.helper = FormHelper()
     test_form.helper.layout = Layout("email")
     html = render_crispy_form(test_form)
 
@@ -311,7 +306,6 @@ def test_specialspaceless_not_screwing_intended_spaces():
     # see issue #250
     test_form = SampleForm()
     test_form.fields["email"].widget = forms.Textarea()
-    test_form.helper = FormHelper()
     test_form.helper.layout = Layout("email", HTML("<span>first span</span> <span>second span</span>"))
     html = render_crispy_form(test_form)
     assert "<span>first span</span> <span>second span</span>" in html
@@ -344,7 +338,6 @@ def test_keepcontext_context_manager():
     # Test case for issue #180
     # Apparently it only manifest when using render_to_response this exact way
     form = CheckboxesSampleForm()
-    form.helper = FormHelper()
     # We use here InlineCheckboxes as it updates context in an unsafe way
     form.helper.layout = Layout("checkboxes", InlineCheckboxes("alphacheckboxes"), "numeric_multiple_checkboxes")
     context = {"form": form}
@@ -356,12 +349,10 @@ def test_keepcontext_context_manager():
 
 def test_update_attributes_class():
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout("email", Field("password1"), "password2")
     form.helper["password1"].update_attributes(css_class="hello")
     html = render_crispy_form(form)
     assert html.count(' class="hello') == 1
-    form.helper = FormHelper()
     form.helper.layout = Layout(
         "email",
         Field("password1", css_class="hello"),

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -18,7 +18,6 @@ from .forms import (
     CrispyEmptyChoiceTestModel,
     CrispyTestModel,
     SampleForm,
-    SampleForm2,
     SampleForm3,
     SampleForm4,
     SampleForm6,
@@ -276,7 +275,7 @@ def test_i18n():
 
 
 def test_default_layout():
-    test_form = SampleForm2()
+    test_form = SampleForm()
     assert test_form.helper.layout.fields == [
         "is_company",
         "email",

--- a/tests/test_layout_objects.py
+++ b/tests/test_layout_objects.py
@@ -31,7 +31,6 @@ from .forms import (
 
 def test_field_with_custom_template():
     test_form = SampleForm()
-    test_form.helper = FormHelper()
     test_form.helper.layout = Layout(Field("email", template="custom_field_template.html"))
 
     html = render_crispy_form(test_form)
@@ -47,7 +46,6 @@ def test_multiwidget_field():
     )
 
     test_form = SampleForm()
-    test_form.helper = FormHelper()
     test_form.helper.layout = Layout(
         MultiWidgetField(
             "datetime_field",
@@ -75,7 +73,6 @@ def test_field_type_hidden():
     )
 
     test_form = SampleForm()
-    test_form.helper = FormHelper()
     test_form.helper.layout = Layout(
         Field("email", type="hidden", data_test=12),
         Field("datetime_field"),
@@ -93,7 +90,6 @@ def test_field_type_hidden():
 
 def test_field_wrapper_class():
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(Field("email", wrapper_class="testing"))
 
     html = render_crispy_form(form)
@@ -102,7 +98,6 @@ def test_field_wrapper_class():
 
 def test_html_with_carriage_returns():
     test_form = SampleForm()
-    test_form.helper = FormHelper()
     test_form.helper.layout = Layout(
         HTML(
             """
@@ -121,7 +116,6 @@ def test_html_with_carriage_returns():
 def test_i18n():
     activate("es")
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout(HTML(_("Enter a valid value.")))
     html = render_crispy_form(form)
     assert "Introduzca un valor válido" in html
@@ -148,7 +142,6 @@ class TestBootstrapLayoutObjects:
         # Make sure an inherited RadioSelect gets rendered as it
         form = SampleFormCustomWidgets()
         assert isinstance(form.fields["inline_radios"].widget, CustomRadioSelect)
-        form.helper = FormHelper()
         form.helper.layout = Layout("inline_radios")
 
         html = render_crispy_form(form)
@@ -162,14 +155,12 @@ class TestBootstrapLayoutObjects:
 
     def test_inline_radios(self):
         test_form = CheckboxesSampleForm()
-        test_form.helper = FormHelper()
         test_form.helper.layout = Layout(InlineRadios("inline_radios"))
         html = render_crispy_form(test_form)
         assert html.count('radio-inline"') == 2
 
     def test_accordion_and_accordiongroup(self):
         test_form = SampleForm()
-        test_form.helper = FormHelper()
         test_form.helper.layout = Layout(
             Accordion(
                 AccordionGroup("one", "first_name"),
@@ -189,7 +180,6 @@ class TestBootstrapLayoutObjects:
 
     def test_accordion_active_false_not_rendered(self):
         test_form = SampleForm()
-        test_form.helper = FormHelper()
         test_form.helper.layout = Layout(
             Accordion(
                 AccordionGroup("one", "first_name"),
@@ -216,7 +206,6 @@ class TestBootstrapLayoutObjects:
 
     def test_alert(self):
         test_form = SampleForm()
-        test_form.helper = FormHelper()
         test_form.helper.layout = Layout(Alert(content="Testing..."))
         html = render_crispy_form(test_form)
 
@@ -226,7 +215,6 @@ class TestBootstrapLayoutObjects:
 
     def test_alert_block(self):
         test_form = SampleForm()
-        test_form.helper = FormHelper()
         test_form.helper.layout = Layout(Alert(content="Testing...", block=True))
         html = render_crispy_form(test_form)
 
@@ -235,7 +223,6 @@ class TestBootstrapLayoutObjects:
 
     def test_tab_and_tab_holder(self):
         test_form = SampleForm()
-        test_form.helper = FormHelper()
         test_form.helper.layout = Layout(
             TabHolder(
                 Tab("one", "first_name", css_id="custom-name", css_class="first-tab-class active"),
@@ -314,7 +301,6 @@ class TestBootstrapLayoutObjects:
         for field in form.fields:
             form.fields[field].widget = forms.HiddenInput()
 
-        form.helper = FormHelper()
         form.helper.layout = Layout(
             AppendedText("password1", "foo"),
             PrependedText("password2", "bar"),
@@ -333,7 +319,6 @@ class TestBootstrapLayoutObjects:
 
         assert html.count("checked") == 6
 
-        test_form.helper = FormHelper(test_form)
         test_form.helper[1].wrap(InlineCheckboxes, inline=True)
         html = render_crispy_form(test_form)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,7 +89,6 @@ def test_contains_partial():
 
 def test_parse_expected_and_form():
     form = SampleForm()
-    form.helper = FormHelper()
     form.helper.layout = Layout("is_company")
     assert parse_form(form) == parse_expected("utils_test.html")
 


### PR DESCRIPTION
Many of the tests have something like this....

```python
def test_sample_form():
    form = SampleForm()
    form.helper = FromHelper()
    ...
```

Instead, we can add an instance level helper to the test forms. This is the approach suggested in the docs, and will help when trying to type the tests. I hope to avoid many occasions of `error: "SampleForm" has no attribute "helper"  [attr-defined]`

https://django-crispy-forms.readthedocs.io/en/latest/crispy_tag_forms.html#fundamentals