### PR TITLE
Simplified isort config and moved to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,7 @@
 line-length = 119
 target-version = ['py37']
 include = '(crispy_forms)\/(.+)(py?$)'
+
+[tool.isort]
+profile = "black"
+line_length = 119

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,15 +2,8 @@
 license_file = LICENSE.txt
 
 [isort]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=119
-default_section=THIRDPARTY
-known_django=django
-known_first_party=crispy_forms
-sections=FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
+profile = black
+line_length = 119
 
 [tool:pytest]
 markers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,6 @@
 [metadata]
 license_file = LICENSE.txt
 
-[isort]
-profile = black
-line_length = 119
-
 [tool:pytest]
 markers =
     only: Parametrized mark to limit a test to a single template pack

--- a/tests/test_dynamic_api.py
+++ b/tests/test_dynamic_api.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django import forms
 
 from crispy_forms.bootstrap import AppendedText

--- a/tests/test_form_helper.py
+++ b/tests/test_form_helper.py
@@ -1,8 +1,7 @@
 import re
 
-import pytest
-
 import django
+import pytest
 from django import forms
 from django.forms.models import formset_factory
 from django.middleware.csrf import _get_new_csrf_string

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django import forms
 from django.forms.models import formset_factory, modelformset_factory
 from django.shortcuts import render

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django.forms.boundfield import BoundField
 from django.forms.formsets import formset_factory
 from django.template import Context, Template

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django import forms
 from django.conf import settings
 from django.template.base import Template


### PR DESCRIPTION
I'm going to see if I can move to using `build` to build this package. Towards this aim I'll also look over the other config files to see if they need updating and/or can be simplified. 

First up, isort. There's an opportunity here to simplify the config settings significantly, with a fairly small impact on the import order. 