### PR TITLE
Removed unused pytest fixtures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,6 @@
 license_file = LICENSE.txt
 
 [tool:pytest]
-markers =
-    only: Parametrized mark to limit a test to a single template pack
 DJANGO_SETTINGS_MODULE= tests.test_settings
 
 [coverage:run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,16 +19,3 @@ def advanced_layout():
         ),
         "last_name",
     )
-
-
-@pytest.fixture(autouse=True, params=(["bootstrap3"]))
-def template_packs(request, settings):
-    check_template_pack(request.node, request.param)
-    settings.CRISPY_TEMPLATE_PACK = request.param
-
-
-def check_template_pack(node, template_pack):
-    mark = node.get_closest_marker("only")
-    if mark:
-        if template_pack not in mark.args:
-            pytest.skip("Requires %s template pack" % " or ".join(mark.args))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -22,6 +22,7 @@ MIDDLEWARE_CLASSES = (
 
 ROOT_URLCONF = "tests.urls"
 CRISPY_CLASS_CONVERTERS = {"textinput": "textinput textInput inputtext"}
+CRISPY_TEMPLATE_PACK = "bootstrap3"
 SECRET_KEY = "secretkey"
 SITE_ROOT = os.path.dirname(os.path.abspath(__file__))
 USE_TZ = True


### PR DESCRIPTION
Now the template packs have been removed from core we can set the `CRISPY_TEMPLATE_PACK` in test_settings and remove the pytest fixture and associated items.

Finally worked out how to do this 😄 