### PR TITLE
Simplified flake8 config and moved to tox.ini

### DIFF
--- a/crispy_forms/helper.py
+++ b/crispy_forms/helper.py
@@ -289,7 +289,7 @@ class FormHelper(DynamicLayoutHandler):
 
         return mark_safe(html)
 
-    def get_attributes(self, template_pack=TEMPLATE_PACK):  # noqa: C901
+    def get_attributes(self, template_pack=TEMPLATE_PACK):
         """
         Used by crispy_forms_tags to get helper attributes
         """

--- a/crispy_forms/utils.py
+++ b/crispy_forms/utils.py
@@ -26,7 +26,7 @@ def default_field_template(template_pack=TEMPLATE_PACK):
     return get_template("%s/field.html" % template_pack)
 
 
-def render_field(  # noqa: C901
+def render_field(
     field,
     form,
     context,

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,10 +6,3 @@ DJANGO_SETTINGS_MODULE= tests.test_settings
 
 [coverage:run]
 branch = True
-
-[flake8]
-exclude =
-    # The conf file is auto generated, ignore it
-    docs/conf.py
-# mirrors max-line-length of Django. This is shorter than GitHub editor (127)
-max-line-length = 119

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,8 +13,3 @@ exclude =
     docs/conf.py
 # mirrors max-line-length of Django. This is shorter than GitHub editor (127)
 max-line-length = 119
-statistics = True
-max-complexity = 10
-count = True
-select = C,E,F,W,B
-ignore = E203, W503

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ skip_install = true
 commands =
     black crispy_forms setup.py --check
     isort crispy_forms setup.py --check --dif
-    flake8 crispy_forms setup.py
+    flake8 crispy_forms setup.py tests
 deps =
     -rrequirements/lint.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,3 +27,9 @@ commands =
     flake8 crispy_forms setup.py
 deps =
     -rrequirements/lint.txt
+
+[flake8]
+exclude =
+    # The conf file is auto generated, ignore it
+    docs/conf.py
+max-line-length = 119


### PR DESCRIPTION
I think we should simplify the flake8 config and go with the defaults. 

I'm aware that removing `max-complexity = 10` results in removing the macabe checks, but given we have `# noqa` against those failures (and have previously concluded, that's a pragmatic solution) it seems we end up in the same place anyway.