### PR TITLE
Improved coverage of black linting.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ from django.conf import settings
 
 settings.configure()
 
-numpydoc_show_class_members = False 
+numpydoc_show_class_members = False
 
 # -- General configuration -----------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.black]
 line-length = 119
 target-version = ['py37']
-include = '(crispy_forms)\/(.+)(py?$)'
 
 [tool.isort]
 profile = "black"

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
 [testenv:lint]
 skip_install = true
 commands =
-    black crispy_forms setup.py --check
+    black . --check
     isort crispy_forms setup.py --check --dif
     flake8 crispy_forms setup.py tests
 deps =


### PR DESCRIPTION
Currently black wasn't being run in CI against the test suite. This simplifies the setup and ensures all files are included.

By including the `docs/conf.py` file, there was one small whitespace change to make. 