### PR TITLE
Moved coverage config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ target-version = ['py37']
 [tool.isort]
 profile = "black"
 line_length = 119
+
+[tool.coverage.run]
+branch = true

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,4 +1,4 @@
-coverage
+coverage[toml]
 pytest
 pytest-cov
 pytest-django

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,3 @@ license_file = LICENSE.txt
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE= tests.test_settings
-
-[coverage:run]
-branch = True


### PR DESCRIPTION
toml was added to the standard library in Python 3.11. Therefore need to install the toml extra with coverage for Python3.7-3.10. Refs https://coverage.readthedocs.io/en/7.0.1/config.html#configuration-reference