### PR TITLE
Drop Django 4.2 Classifier.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers=[
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
-    "Framework :: Django :: 4.2",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: JavaScript",


### PR DESCRIPTION
The 4.2 classifier is not yet available and is blocking the 2.0a1 release.