### PR TITLE
Submit, Reset btn default css_class changed

### DIFF
--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -321,7 +321,7 @@ class Submit(BaseInput):
     """
 
     input_type = "submit"
-    field_classes = "btn btn-primary"
+    field_classes = "btn"
 
 
 class Button(BaseInput):
@@ -506,7 +506,7 @@ class Reset(BaseInput):
     """
 
     input_type = "reset"
-    field_classes = "btn btn-inverse"
+    field_classes = "btn"
 
 
 class Fieldset(LayoutObject):


### PR DESCRIPTION
 (from this stackoverflow issue: https://stackoverflow.com/q/75603468/7456750)

There is a default CSS class like `btn-primary` and `btn-inverse` in the `Submit` and `Reset` (input) buttons.
```py
class Submit(BaseInput):
    # ...
    input_type = "submit"
    field_classes = "btn btn-primary"
```
```py
class Reset(BaseInput):
    # ...
    input_type = "reset"
    field_classes = "btn btn-inverse"
```

So the default CSS class is changed. Although when users add new CSS classes to `css_classes` they are added after the default classes. So let users modify the `Submit` and `Reset` btn classes.