### PR TITLE
Updated PreprendText docs to show mark_safe being used for HTML text.

### DIFF
--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -195,7 +195,7 @@ These ones live under module ``crispy_forms.bootstrap``.
 .. image:: images/form_actions.png
    :align: center
 
-- **AppendedText**: It renders a bootstrap appended text input. The first parameter is the name of the field to add appended text to, then the appended text which can be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render appended text active. See `input_size`_ to change the size of this input::
+- **AppendedText**: It renders a bootstrap appended text input. The first parameter is the name of the field to add appended text to. The second is the appended text which can be wrapped in Django's `mark_safe`_ to allow it to be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render appended text active. See `input_size`_ to change the size of this input::
 
     AppendedText('field_name', 'appended text to show')
     AppendedText('field_name', '$', active=True)
@@ -203,15 +203,15 @@ These ones live under module ``crispy_forms.bootstrap``.
 .. image:: images/appended_text.png
    :align: center
 
-- **PrependedText**: It renders a bootstrap prepended text input. The first parameter is the name of the field to add prepended text to, then the prepended text which can be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render prepended text active. See `input_size`_ to change the size of this input::
+- **PrependedText**: It renders a bootstrap prepended text input. The first parameter is the name of the field to add prepended text to. The second is the prepended text which can be wrapped in Django's `mark_safe`_ to allow it to be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render prepended text active. See `input_size`_ to change the size of this input::
 
-    PrependedText('field_name', '<b>Prepended text</b> to show')
+    PrependedText('field_name', mark_safe('<b>Prepended text</b> to show'))
     PrependedText('field_name', '@', placeholder="username")
 
 .. image:: images/prepended_text.png
    :align: center
 
-- **PrependedAppendedText**: It renders a combined prepended and appended text. The first parameter is the name of the field, then the prepended text and finally the appended text. See `input_size`_ to change the size of this input::
+- **PrependedAppendedText**: It renders a combined prepended and appended text. The first parameter is the name of the field, then the prepended text and finally the appended text. The text can be wrapped in Django's `mark_safe`_ to allow it to be HTML like. See `input_size`_ to change the size of this input::
 
     PrependedAppendedText('field_name', '$', '.00'),
 
@@ -318,6 +318,8 @@ These ones live under module ``crispy_forms.bootstrap``.
 
 .. image:: images/modal.png
     :align: center
+
+.. _`mark_safe`: https://docs.djangoproject.com/en/dev/ref/utils/#django.utils.safestring.mark_safe
 
 .. _`input_size`:
 


### PR DESCRIPTION
Since django-crispy-forms version 2 the `|safe` filters are removed. Instead the strings can be wrapped with `mark_safe()` in user code.