### PR TITLE
Dropped support for Python 3.7.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG for django-crispy-forms
 
+## Next Release (TBC)
+* Dropped support for Python 3.7.
+
 ## 2.0 (2023-02-13)
 Release of django-crispy-forms 2.0. No changes introduced since 2.0a1.
 

--- a/README.rst
+++ b/README.rst
@@ -12,9 +12,7 @@ django-crispy-forms
 
 The best way to have Django_ DRY forms. Build programmatic reusable layouts out of components, having full control of the rendered HTML without writing HTML in templates. All this without breaking the standard way of doing things in Django, so it plays nice with any other form application.
 
-`django-crispy-forms` supports Django 3.2+ with Python 3.7+.
-
-**Note: Django 4.0+ requires version 1.13+.**
+`django-crispy-forms` supports Django 3.2+ with Python 3.8+.
 
 Looking for Bootstrap 5 support? See the `crispy-bootstrap5 package`_.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-crispy-forms"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 description = "Best way to have Django DRY forms"
 classifiers=[
     "Development Status :: 5 - Production/Stable",
@@ -17,7 +17,6 @@ classifiers=[
     "Operating System :: OS Independent",
     "Programming Language :: JavaScript",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -43,7 +42,7 @@ version = {attr = "crispy_forms.__version__"}
 
 [tool.black]
 line-length = 119
-target-version = ['py37']
+target-version = ['py38']
 
 [tool.isort]
 profile = "black"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    {py37,py38,py39,py310}-django{32},
-    {py38,py39,py310}-django{40,41,42,-latest},
+    {py38,py39,py310}-django{32,40,41,42,-latest},
     {py311}-django{41,42,-latest},
     lint
 


### PR DESCRIPTION
Python 3.7 support ends on 27 Jun 2023.