### PR TITLE
Drop Django 4.0 and 4.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release (TBC)
 * Added support for Django 5.0.
+* Dropped support for Django 4.0 and 4.1.
 * Add support for Python 3.12.
 * Dropped support for Python 3.7.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ classifiers=[
     "Environment :: Web Environment",
     "Framework :: Django",
     "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "License :: OSI Approved :: MIT License",

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
 envlist =
-    {py38,py39,py310}-django{32,40,41,42,-latest},
+    {py38,py39,py310}-django{32,42},
     {py310}-{django50}
-    {py311,py312}-django{41,42,50,-latest},
+    {py311,py312}-django{42,50,-latest},
     lint
 
 [testenv]
 deps =
     django32: django>=3.2,<3.3
-    django40: django>=4.0a,<4.1
-    django41: django>=4.1a,<4.2
     django42: django>=4.2a,<5.0
     django50: django>=5.0a,<5.1
     django-latest: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
As I understand it Django recomends dropping 4.1 upon release of 5.0. That's only a few weeks away now so I'm doing that now. 

Maybe that's too early, but it's only really classifers that will change, it will still work as we still have `dependencies = ["django>=3.2"]`.

If it's too early, we can just hold a release back a few weeks, there's not been any funcionality change since 2.0. 