### PR TITLE
Dropped support for Django 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next Release (TBC)
 * Added support for Django 5.0.
-* Dropped support for Django 4.0 and 4.1.
+* Dropped support for Django 3.2, 4.0 and 4.1.
 * Add support for Python 3.12.
 * Dropped support for Python 3.7.
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ django-crispy-forms
 
 The best way to have Django_ DRY forms. Build programmatic reusable layouts out of components, having full control of the rendered HTML without writing HTML in templates. All this without breaking the standard way of doing things in Django, so it plays nice with any other form application.
 
-`django-crispy-forms` supports Django 3.2+ with Python 3.8+.
+`django-crispy-forms` supports Django 4.2+ with Python 3.8+.
 
 Looking for Bootstrap 5 support? See the `crispy-bootstrap5 package`_.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "License :: OSI Approved :: MIT License",
@@ -27,7 +26,7 @@ classifiers=[
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 license = {text = "MIT"}
-dependencies = ["django>=3.2"]
+dependencies = ["django>=4.2"]
 authors = [{name = "Miguel Araujo", email = "miguel.araujo.perez@gmail.com"}]
 dynamic = ['version']
 readme = "README.rst"

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
 envlist =
-    {py38,py39,py310}-django{32,42},
-    {py310}-{django50}
-    {py311,py312}-django{42,50,-latest},
+    {py38,py39,py310,py311}-django{42},
+    {py310,py311,py312}-django{50,-latest},
     lint
 
 [testenv]
 deps =
-    django32: django>=3.2,<3.3
     django42: django>=4.2a,<5.0
     django50: django>=5.0a,<5.1
     django-latest: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
Revisiting this, the Django doc's recommend dropping 3.2 when 5.0 is released (which we're nearly at). 

https://docs.djangoproject.com/en/5.0/releases/5.0/#third-party-library-support-for-older-version-of-django