### PR TITLE
add css class to prepended/appended inline elements 

### DIFF
--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -269,7 +269,7 @@ class PrependedText(PrependedAppendedText):
             active=active,
             css_class=css_class,
             wrapper_class=wrapper_class,
-            prepended_class = prepended_class
+            prepended_class = prepended_class,
             template=template,
             **kwargs,
         )

--- a/crispy_forms/bootstrap.py
+++ b/crispy_forms/bootstrap.py
@@ -29,8 +29,12 @@ class PrependedAppendedText(Field):
         The name of the field to be rendered.
     prepended_text : str, optional
         The prepended text, can be HTML like, by default None
+    prepended_class : str, optional
+        The prepended class defines the css classes for the prepended text
     appended_text : str, optional
         The appended text, can be HTML like, by default None
+    appended_class : str, optional
+        The appended class defines the css classes for the appended text
     input_size : str, optional
         For Bootstrap4+ additional classes to customise the input-group size
         e.g. ``input-group-sm``. By default None
@@ -65,6 +69,8 @@ class PrependedAppendedText(Field):
         field,
         prepended_text=None,
         appended_text=None,
+        prepended_class=None,
+        appended_class=None,
         input_size=None,
         *,
         active=False,
@@ -74,8 +80,10 @@ class PrependedAppendedText(Field):
         **kwargs,
     ):
         self.field = field
-        self.appended_text = appended_text
         self.prepended_text = prepended_text
+        self.appended_text = appended_text
+        self.prepended_class = prepended_class
+        self.appended_class = appended_class
         self.active = active
 
         self.input_size = input_size
@@ -86,7 +94,7 @@ class PrependedAppendedText(Field):
             if "input-sm" in css_class:
                 self.input_size = "input-sm"
 
-        super().__init__(field, css_class=css_class, wrapper_class=wrapper_class, template=template, **kwargs)
+        super().__init__(field, css_class=css_class, wrapper_class=wrapper_class, prepended_class=prepended_class, appended_class=appended_class, template=template, **kwargs)
 
     def render(self, form, context, template_pack=TEMPLATE_PACK, extra_context=None, **kwargs):
         extra_context = extra_context.copy() if extra_context is not None else {}
@@ -97,6 +105,8 @@ class PrependedAppendedText(Field):
                 "input_size": self.input_size,
                 "active": getattr(self, "active", False),
                 "wrapper_class": self.wrapper_class,
+                "prepended_class": self.prepended_class,
+                "appended_class" : self.appended_class,
             }
         )
         template = self.get_template_name(template_pack)
@@ -132,6 +142,8 @@ class AppendedText(PrependedAppendedText):
         The name of the field to be rendered.
     text : str
         The appended text, can be HTML like.
+    appended_class : str, optional
+        The appended class defines the css classes for the appended text
     input_size : str, optional
         For Bootstrap4+ additional classes to customise the input-group size
         e.g. ``input-group-sm``. By default None
@@ -168,10 +180,12 @@ class AppendedText(PrependedAppendedText):
         active=False,
         css_class=None,
         wrapper_class=None,
+        appended_class=None,
         template=None,
         **kwargs,
     ):
         self.text = text
+        self.appended_class = appended_class
         super().__init__(
             field,
             appended_text=text,
@@ -179,6 +193,7 @@ class AppendedText(PrependedAppendedText):
             active=active,
             css_class=css_class,
             wrapper_class=wrapper_class,
+            appended_class=appended_class,
             template=template,
             **kwargs,
         )
@@ -217,6 +232,8 @@ class PrependedText(PrependedAppendedText):
         CSS classes to be used when rendering the Field. This class is usually
         applied to the ``<div>`` which wraps the Field's ``<label>`` and
         ``<input>`` tags. By default ``None``.
+    prepended_class : str, optional
+        The prepended class defines the css classes for the prepended text
     template : str, optional
         Overrides the default template, if provided. By default ``None``.
     **kwargs : dict, optional
@@ -240,6 +257,7 @@ class PrependedText(PrependedAppendedText):
         active=False,
         css_class=None,
         wrapper_class=None,
+        prepended_class=None,
         template=None,
         **kwargs,
     ):
@@ -251,6 +269,7 @@ class PrependedText(PrependedAppendedText):
             active=active,
             css_class=css_class,
             wrapper_class=wrapper_class,
+            prepended_class = prepended_class
             template=template,
             **kwargs,
         )

--- a/docs/layouts.rst
+++ b/docs/layouts.rst
@@ -195,25 +195,28 @@ These ones live under module ``crispy_forms.bootstrap``.
 .. image:: images/form_actions.png
    :align: center
 
-- **AppendedText**: It renders a bootstrap appended text input. The first parameter is the name of the field to add appended text to. The second is the appended text which can be wrapped in Django's `mark_safe`_ to allow it to be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render appended text active. See `input_size`_ to change the size of this input::
+- **AppendedText**: It renders a bootstrap appended text input. The first parameter is the name of the field to add appended text to. The second is the appended text which can be wrapped in Django's `mark_safe`_ to allow it to be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render appended text active. The optional parameter ``appended_class`` gives you the option of customizing the span element with css tags. See `input_size`_ to change the size of this input::
 
     AppendedText('field_name', 'appended text to show')
     AppendedText('field_name', '$', active=True)
+    AppendedText('field_name', '$', active=True, appended_class='bg-success')
 
 .. image:: images/appended_text.png
    :align: center
 
-- **PrependedText**: It renders a bootstrap prepended text input. The first parameter is the name of the field to add prepended text to. The second is the prepended text which can be wrapped in Django's `mark_safe`_ to allow it to be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render prepended text active. See `input_size`_ to change the size of this input::
+- **PrependedText**: It renders a bootstrap prepended text input. The first parameter is the name of the field to add prepended text to. The second is the prepended text which can be wrapped in Django's `mark_safe`_ to allow it to be HTML like. There is an optional parameter ``active``, by default set to ``False``, that you can set to a boolean to render prepended text active. The optional parameter ``prepended_class`` gives you the option of customizing the span element with css tags. See `input_size`_ to change the size of this input::
 
     PrependedText('field_name', mark_safe('<b>Prepended text</b> to show'))
     PrependedText('field_name', '@', placeholder="username")
+    AppendedText('field_name', '$', active=True, prepended_class='bg-success')
 
 .. image:: images/prepended_text.png
    :align: center
 
-- **PrependedAppendedText**: It renders a combined prepended and appended text. The first parameter is the name of the field, then the prepended text and finally the appended text. The text can be wrapped in Django's `mark_safe`_ to allow it to be HTML like. See `input_size`_ to change the size of this input::
+- **PrependedAppendedText**: It renders a combined prepended and appended text. The first parameter is the name of the field, then the prepended text and finally the appended text. The text can be wrapped in Django's `mark_safe`_ to allow it to be HTML like. The optional parameters ``prepended_class`` and ``appended_class`` gives you the option of customizing the span elements with css tags. See `input_size`_ to change the size of this input::
 
     PrependedAppendedText('field_name', '$', '.00'),
+    PrependedAppendedText('field_name', '$', '.00', prepended_class='bg-danger', appended_class='bg-success'),
 
 .. image:: images/appended_prepended_text.png
    :align: center


### PR DESCRIPTION
If I want to apply my own formatting to the "add-on" in the "input-group" element https://getbootstrap.com/docs/5.0/forms/input-group/, this is not possible due to the lack of parameterization. However, this would make sense if, for example, the background color or the size needs to be adjusted. In addition, css tricks could also be used to create nice effects. For this case I have created this patch in combination with the pull-request of crispy-bootstrap5. 