### PR TITLE
Revert "Allowed pass through of context when rendering a layout object. (#1377)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 2.2 (TBC)
 * Added support for Django 5.1.
-* Allowed pass through of context when rendering a ``Fieldset`` layout object.
 
 ## 2.1 (2023-10-15)
 * Added support for Django 5.0.

--- a/crispy_forms/layout.py
+++ b/crispy_forms/layout.py
@@ -584,8 +584,7 @@ class Fieldset(LayoutObject):
             legend = SafeString("")
 
         template = self.get_template_name(template_pack)
-        context.update({"fieldset": self, "legend": legend, "fields": fields})
-        return render_to_string(template, context.flatten())
+        return render_to_string(template, {"fieldset": self, "legend": legend, "fields": fields})
 
 
 class MultiField(LayoutObject):

--- a/tests/templates/custom_fieldset_template_with_context.html
+++ b/tests/templates/custom_fieldset_template_with_context.html
@@ -1,2 +1,0 @@
-<h1>Special custom fieldset with context passthrough</h1>
-Got context var: {{ fieldset_context_var }}.

--- a/tests/test_layout_objects.py
+++ b/tests/test_layout_objects.py
@@ -17,7 +17,7 @@ from crispy_forms.bootstrap import (
     TabHolder,
 )
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import HTML, Field, Fieldset, Layout, MultiWidgetField
+from crispy_forms.layout import HTML, Field, Layout, MultiWidgetField
 from crispy_forms.utils import render_crispy_form
 
 from .forms import (
@@ -134,22 +134,6 @@ def test_remove_labels():
     html = render_crispy_form(form)
 
     assert "<label" not in html
-
-
-def test_passthrough_context():
-    """
-    Test to ensure that context is passed through implicitly from outside of
-    the crispy form into the crispy form templates.
-    """
-    form = SampleForm()
-    form.helper.layout = Layout(
-        Fieldset("", template="custom_fieldset_template_with_context.html"),
-    )
-
-    c = {"fieldset_context_var": "fieldset_context_value"}
-
-    html = render_crispy_form(form, helper=form.helper, context=c)
-    assert "Got context var: fieldset_context_value" in html
 
 
 class TestBootstrapLayoutObjects:


### PR DESCRIPTION
This reverts commit f9d67d3e164c52f05a3465bce6aada099ad6fd9f.

I'm a bit confused to be honest. I am pretty certain I saw the checks pass on the PR page after I pushed my edits, but clearly that wasn't the case. 

The error is a bit odd -- the tests don't even run! Instead the error message is _"GitHub Actions has encountered an internal error when running your job"_. Anyway let's see if reverting this fixes the issue. 