### PR TITLE
PEP 639 licenses 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers=[
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: JavaScript",
     "Programming Language :: Python :: 3",
@@ -28,7 +27,8 @@ classifiers=[
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE.txt"]
 dependencies = ["django>=4.2"]
 authors = [{name = "Miguel Araujo", email = "miguel.araujo.perez@gmail.com"}]
 dynamic = ['version']


### PR DESCRIPTION
Warnings are now being raised when building the package related to this change. 


https://peps.python.org/pep-0639/ specifies how licenses are to be documented.

The guide here https://packaging.python.org/en/latest/guides/licensing-examples-and-user-scenarios/ is helpful.

1. Switch the 'MIT License' classifier to use 'license = "MIT"' instead. (As in the 'basic example' in the PyPA guide.
2. Add a 'license-files' for the license where we're using a non-standard (?) 'LICENSE.txt' file name.

