### PR TITLE
Enabled GitHub code of conduct.

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+This project follows Django's Code of Conduct.
+
+See https://www.djangoproject.com/conduct/


### PR DESCRIPTION
Adding a reference to say that we follow Django's code of conduct.

See [docs](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project) and discussion from when this was added to Django itself: https://github.com/django/django/pull/15057

