### PR TITLE
Added security policy.

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,1 @@
+Please report security issues to crispy-forms@smithdc.uk


### PR DESCRIPTION
One of the requirements for Tidelift is to have a security policy.

Looking around 👀  , other projects seem to have a file like what is proposed here. 

I was going to use my 'sm***** at gmail' account here. But rather than making that more public, I thought I would route a custom email address to it instead.