### PR TITLE
Update crispy_forms_tags.py

### DIFF
--- a/crispy_forms/templatetags/crispy_forms_tags.py
+++ b/crispy_forms/templatetags/crispy_forms_tags.py
@@ -50,7 +50,7 @@ class ForLoopSimulator:
         self.revcounter -= 1
         self.revcounter0 -= 1
         self.first = False
-        self.last = self.revcounter0 == self.len_values - 1
+        self.last = self.revcounter0 == 0
 
 
 class BasicNode(template.Node):


### PR DESCRIPTION
BUGFIX: forloop.last should be true when revcounter0 hits 0 (it starts as self.len_values - 1)