### PR TITLE
Bumped workflow and RTD versions. 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,9 @@ jobs:
         - '3.14'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,9 @@ jobs:
         - '3.14'
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -47,9 +47,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.10'
     - name: Install dependencies

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,9 +8,9 @@ sphinx:
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.14"
 
 # Build all formats
 formats: all


### PR DESCRIPTION
Bumping versions ahead of a release I hope to make soon. A couple of notes:

- I thought we had dependabot set up to open PRs for the workflows 🤔 
- Codecov needs a more in depth review to support latest versions. It seems we may need tokens and/or config changes. 